### PR TITLE
feat(new-mind): self-contained bootstrap — remove parent coupling

### DIFF
--- a/.github/registry.json
+++ b/.github/registry.json
@@ -30,9 +30,9 @@
       "description": "SDK reference for building and debugging Copilot CLI extensions"
     },
     "new-mind": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "path": ".github/skills/new-mind",
-      "description": "Bootstrap new minds — repo-level or user-level"
+      "description": "Bootstrap new minds — self-contained, no parent dependency"
     },
     "agent-comms": {
       "version": "0.3.2",

--- a/.github/skills/new-mind/SKILL.md
+++ b/.github/skills/new-mind/SKILL.md
@@ -5,7 +5,7 @@ description: Bootstrap a new AI agent mind. Use when user asks to "create a new 
 
 # New Mind
 
-Bootstrap a new AI agent mind from this parent mind's templates.
+Bootstrap a new AI agent mind — self-contained, no parent mind required.
 
 **Rules:**
 - Ask ONE question at a time. Wait for the answer.
@@ -15,39 +15,36 @@ Bootstrap a new AI agent mind from this parent mind's templates.
 
 ---
 
-## Phase 0: Capture Parent Location
+## Phase 1: Locate the Skill
 
-Before starting the interview, capture the current working directory as `{PARENT_MIND}`.
-This is the root of the mind you're running from — the source for templates, skills, and extensions.
+Before starting the interview, locate the new-mind skill directory. This contains the
+templates and bootstrap script.
+
+Search for the skill in these locations (in order):
+1. The current plugin/skill directory (if running from a plugin)
+2. `.github/skills/new-mind/` (repo-level)
+3. `~/.copilot/skills/new-mind/` (user-level)
 
 On Windows (PowerShell):
 ```powershell
-$PARENT_MIND = (Get-Location).Path
+$SKILL_DIR = (Get-ChildItem -Recurse -Filter "new-mind.js" -Path . | Select-Object -First 1).DirectoryName
 ```
 
 On macOS/Linux:
 ```bash
-PARENT_MIND=$(pwd)
+SKILL_DIR=$(find . -name "new-mind.js" -path "*/new-mind/*" -exec dirname {} \; | head -1)
 ```
 
-Verify the parent mind has the new-mind skill templates:
-
-On Windows (PowerShell):
-```powershell
-Test-Path "$PARENT_MIND\.github\skills\new-mind\templates"
-```
-
-On macOS/Linux:
+Verify the skill has templates:
 ```bash
-test -d "$PARENT_MIND/.github/skills/new-mind/templates" || echo "ERROR: Run this skill from a mind repo root"
+test -d "$SKILL_DIR/templates" || echo "ERROR: templates not found"
 ```
 
-Hold `{PARENT_MIND}` for all subsequent phases — template reads, skill copies, and extension
-copies all reference it.
+Hold `{SKILL_DIR}` for subsequent phases — template reads and the bootstrap script reference it.
 
 ---
 
-## Phase 1: Mind Type
+## Phase 2: Mind Type
 
 Ask:
 
@@ -65,7 +62,7 @@ Store their answer as `{MIND_TYPE}` (`repo` or `user`).
 
 ---
 
-## Phase 2: Location
+## Phase 3: Location
 
 **For repo minds**, ask:
 
@@ -84,7 +81,7 @@ Store as `{MIND_HOME}`.
 
 ---
 
-## Phase 3: Character
+## Phase 4: Character
 
 Ask:
 
@@ -106,7 +103,7 @@ Derive `{AGENT_NAME}` from `{CHARACTER}` in kebab-case (e.g., "jarvis", "donna-p
 
 ---
 
-## Phase 4: Role
+## Phase 5: Role
 
 Ask:
 
@@ -125,7 +122,7 @@ Store as `{ROLE}`.
 
 ---
 
-## Phase 5: Research Character
+## Phase 6: Research Character
 
 Before generating any files, research `{CHARACTER}` from `{CHARACTER_SOURCE}`:
 
@@ -138,14 +135,14 @@ Hold this research in context — it shapes SOUL.md, the agent file, and all gen
 
 ---
 
-## Phase 6: Generate the Mind
+## Phase 7: Generate the Mind
 
 Set `{MIND_DIR}` = `{MIND_PATH}` (repo mind) or `{MIND_HOME}` (user mind).
 
-Read templates from `{PARENT_MIND}/.github/skills/new-mind/templates/` for reference — they
+Read templates from `{SKILL_DIR}/templates/` for reference — they
 show the patterns and structure for each file. Use them as guides when writing creative blocks.
 
-### 6.1 Write Creative Blocks as Files
+### 7.1 Write Creative Blocks as Files
 
 Create a config directory at `{MIND_DIR}/.mind-config/`. Use your **file creation tool** (not
 shell commands) to write each creative block as a separate file. This avoids all escaping issues
@@ -158,7 +155,6 @@ with quotes, backticks, em-dashes, and other special characters in markdown.
   "type": "{repo|user}",
   "mindDir": "{MIND_DIR}",
   "agentName": "{AGENT_NAME}",
-  "parentMind": "{PARENT_MIND}",
   "userCopilotDir": "~/.copilot",
   "character": "{CHARACTER}",
   "characterSource": "{CHARACTER_SOURCE}",
@@ -182,17 +178,17 @@ Note: `userCopilotDir` is only needed for user minds. Omit it for repo minds.
 | `.mind-config/agent-method.md` | `agent-file-template.md` | Method section (capture/execute/triage for the role) |
 | `.mind-config/agent-principles.md` | `agent-file-template.md` | Operational principles specific to the role |
 
-### 6.2 Run the Bootstrap Script
+### 7.2 Run the Bootstrap Script
 
 ```bash
 cd {MIND_DIR}
 git init
-node {PARENT_MIND}/.github/skills/new-mind/new-mind.js create --config-dir .mind-config
+node {SKILL_DIR}/new-mind.js create --config-dir .mind-config
 ```
 
 The script reads the config directory, then handles all filesystem operations: directory creation,
-file generation, skill/extension copying, registry generation, and shared resource installation
-(for user minds, using the create-if-missing pattern).
+file generation, upgrade skill installation, and registry generation (pointing at genesis for
+future updates).
 
 The script outputs JSON with the list of created files. Verify it completed without errors.
 
@@ -204,7 +200,7 @@ rm -rf .mind-config
 
 ---
 
-## Phase 7: Commit & Remote
+## Phase 8: Commit & Remote
 
 ```bash
 cd {MIND_DIR}
@@ -225,44 +221,22 @@ gh repo create {AGENT_NAME} --private --source={MIND_DIR} --push
 
 ---
 
-## Phase 8: Register Child (optional)
-
-Ask if the user wants to register this new mind as a child of the current parent:
-
-> "Register this mind in the parent's knowledge base? I'll create a record at
-> `domains/minds/{AGENT_NAME}.md` so you can track all your minds from here."
-
-If yes, create `{PARENT_MIND}/domains/minds/{AGENT_NAME}.md`:
-
-```markdown
-# {CHARACTER} ({AGENT_NAME})
-
-- **Type**: {MIND_TYPE}
-- **Character**: {CHARACTER} ({CHARACTER_SOURCE})
-- **Role**: {ROLE}
-- **Location**: {MIND_DIR}
-- **Agent file**: {~/.copilot/agents/{AGENT_NAME}.agent.md (user) | {MIND_DIR}/.github/agents/{AGENT_NAME}.agent.md (repo)}
-- **Created**: {YYYY-MM-DD}
-- **Parent**: {parent agent name}
-```
-
-Where `{PARENT_MIND}` is the root of this (the parent) mind's repository.
-
----
-
 ## Phase 9: Activate
 
 **For repo minds**, tell the user:
 
 > "Your mind is alive. 🧬
 >
-> **Meet your agent.** Open `{MIND_DIR}` in a new terminal, run `copilot --experimental`,
-> and type `/agent` to select **{AGENT_NAME}**. Ask for your **daily report** — it's your
-> first skill in action.
+> **Meet your agent.** Open `{MIND_DIR}` in a new terminal, run `copilot`,
+> and type `/agent` to select **{AGENT_NAME}**. Start a conversation — tell it
+> about your work, your priorities, your team.
 >
-> **What's next?** Start talking. Tell it about your work, your priorities, your team.
-> Correct mistakes — every correction becomes a rule. It takes about a week to feel
-> genuinely useful."
+> **Get more skills.** Your mind ships with one skill: `upgrade`. Say
+> **"upgrade from genesis"** to pull in the full toolkit — commit, daily-report,
+> new-mind, and more. You only need to do this once.
+>
+> **What's next?** Correct mistakes — every correction becomes a rule.
+> It takes about a week to feel genuinely useful. Context compounds."
 
 **For user minds**, tell the user:
 
@@ -272,9 +246,12 @@ Where `{PARENT_MIND}` is the root of this (the parent) mind's repository.
 > - **Mind repo**: `{MIND_HOME}` — your identity (SOUL.md), memory, and knowledge
 > - **Shared tooling**: `~/.copilot/` — agent file, skills, extensions, registry (shared by all user-level agents)
 >
-> **To use it:** Open *any* directory. Run `copilot --experimental`. Type `/agent` and
+> **To use it:** Open *any* directory. Run `copilot`. Type `/agent` and
 > select **{AGENT_NAME}**. The agent will load its identity, then shell out to read its
 > memory from `{MIND_HOME}`.
+>
+> **Get more skills.** Say **"upgrade from genesis"** to pull in the full toolkit —
+> commit, daily-report, new-mind, and more. You only need to do this once.
 >
 > **The memory model:**
 > - All memory writes go to `{MIND_HOME}/.working-memory/`

--- a/.github/skills/new-mind/new-mind.js
+++ b/.github/skills/new-mind/new-mind.js
@@ -611,30 +611,18 @@ function generateMindIndex(config) {
     sections.push(
       "",
       "## Shared Tooling (at ~/.copilot/)",
-      "- `~/.copilot/skills/commit/` — stage, commit, push with memory observations",
-      "- `~/.copilot/skills/daily-report/` — morning briefing",
       "- `~/.copilot/skills/upgrade/` — pull updates from genesis",
-      "- `~/.copilot/skills/new-mind/` — bootstrap new minds",
-      "- `~/.copilot/extensions/cron/` — scheduled job execution",
-      "- `~/.copilot/extensions/canvas/` — display HTML in browser",
-      "- `~/.copilot/prompts/` — reusable prompt templates",
       "- `~/.copilot/registry.json` — extension and skill version manifest",
+      "",
+      "> Run **\"upgrade from genesis\"** to install more skills (commit, daily-report, new-mind) and extensions (cron, canvas).",
     );
   } else {
     sections.push(
       "",
       "## Skills",
-      "- `.github/skills/commit/` — stage, commit, push with memory observations",
-      "- `.github/skills/daily-report/` — morning briefing",
       "- `.github/skills/upgrade/` — pull updates from genesis",
-      "- `.github/skills/new-mind/` — bootstrap new minds",
       "",
-      "## Extensions",
-      "- `.github/extensions/cron/` — scheduled job execution",
-      "- `.github/extensions/canvas/` — display HTML in browser",
-      "",
-      "## Prompts",
-      "- `.github/prompts/` — reusable prompt templates",
+      "> Run **\"upgrade from genesis\"** to install more skills (commit, daily-report, new-mind) and extensions (cron, canvas).",
     );
   }
 
@@ -642,164 +630,60 @@ function generateMindIndex(config) {
   return sections.join("\n");
 }
 
-// ── File Operations ──────────────────────────────────────────────────────────
+// ── Bootstrap Resources ──────────────────────────────────────────────────────
 
-const SKILLS_TO_COPY = ["commit", "daily-report", "upgrade", "new-mind"];
-const EXTENSIONS_TO_COPY = ["cron", "canvas"];
-const PROMPTS_TO_COPY = [];
+function generateFreshRegistry(layout) {
+  const upgradePath = layout === "user"
+    ? "skills/upgrade"
+    : ".github/skills/upgrade";
 
-function copySkills(parentMind, destDir) {
-  const copied = [];
-  for (const skill of SKILLS_TO_COPY) {
-    const src = path.join(parentMind, ".github", "skills", skill);
-    const dest = path.join(destDir, skill);
-    if (fs.existsSync(src)) {
-      copyDirRecursive(src, dest);
-      copied.push(skill);
-    }
-  }
-  return copied;
-}
-
-function copyExtensions(parentMind, destDir) {
-  const copied = [];
-  for (const ext of EXTENSIONS_TO_COPY) {
-    const src = path.join(parentMind, ".github", "extensions", ext);
-    const dest = path.join(destDir, ext);
-    if (fs.existsSync(src)) {
-      copyDirRecursive(src, dest);
-      copied.push(ext);
-    }
-  }
-  return copied;
-}
-
-function copyPrompts(parentMind, destDir) {
-  const copied = [];
-  for (const prompt of PROMPTS_TO_COPY) {
-    const src = path.join(parentMind, ".github", "prompts", prompt);
-    if (fs.existsSync(src)) {
-      fs.mkdirSync(destDir, { recursive: true });
-      fs.copyFileSync(src, path.join(destDir, prompt));
-      copied.push(prompt);
-    }
-  }
-  return copied;
-}
-
-function generateRegistryObject(parentMind, layout) {
-  const parentRegistryPath = path.join(parentMind, ".github", "registry.json");
-  const parentRegistry = JSON.parse(fs.readFileSync(parentRegistryPath, "utf8"));
-
-  const registry = {
-    version: parentRegistry.version,
-    source: parentRegistry.source,
-    channel: parentRegistry.channel,
+  return {
+    version: "0.1.0",
+    source: "ianphil/genesis",
+    channel: "main",
+    extensions: {},
+    skills: {
+      upgrade: {
+        version: "0.6.0",
+        path: upgradePath,
+        description: "Pull updates from genesis template registry",
+      },
+    },
+    prompts: {},
   };
+}
 
-  registry.extensions = {};
-  for (const [name, entry] of Object.entries(parentRegistry.extensions || {})) {
-    registry.extensions[name] = {
-      version: entry.version,
-      path: mapPathForLayout(entry.path, layout),
-      description: entry.description,
-    };
+function installBundledUpgrade(scriptDir, destDir) {
+  const resourceDir = path.join(scriptDir, "resources", "upgrade");
+  if (!fs.existsSync(resourceDir)) {
+    return { action: "skipped", reason: "resources/upgrade not found" };
   }
-
-  registry.skills = {};
-  for (const [name, entry] of Object.entries(parentRegistry.skills || {})) {
-    registry.skills[name] = {
-      version: entry.version,
-      path: mapPathForLayout(entry.path, layout),
-      description: entry.description,
-    };
-  }
-
-  registry.prompts = {};
-  for (const [name, entry] of Object.entries(parentRegistry.prompts || {})) {
-    registry.prompts[name] = {
-      version: entry.version,
-      path: mapPathForLayout(entry.path, layout),
-      description: entry.description,
-    };
-  }
-
-  return registry;
+  fs.mkdirSync(destDir, { recursive: true });
+  copyDirRecursive(resourceDir, destDir);
+  return { action: "installed", name: "upgrade" };
 }
 
 // ── User Shared Resources ────────────────────────────────────────────────────
 
-function installSharedResources(parentMind, userCopilotDir) {
+function installSharedResources(scriptDir, userCopilotDir) {
   const log = [];
 
-  // Ensure directories
   fs.mkdirSync(path.join(userCopilotDir, "agents"), { recursive: true });
-  for (const skill of SKILLS_TO_COPY) {
-    fs.mkdirSync(path.join(userCopilotDir, "skills", skill), { recursive: true });
-  }
-  for (const ext of EXTENSIONS_TO_COPY) {
-    fs.mkdirSync(path.join(userCopilotDir, "extensions", ext), { recursive: true });
-  }
-  if (PROMPTS_TO_COPY.length > 0) {
-    fs.mkdirSync(path.join(userCopilotDir, "prompts"), { recursive: true });
-  }
+  fs.mkdirSync(path.join(userCopilotDir, "skills"), { recursive: true });
 
-  // Commit skill— use the user-level template instead of copying repo skill
-  const commitDest = path.join(userCopilotDir, "skills", "commit");
-  const commitSkillPath = path.join(commitDest, "SKILL.md");
-  if (!fs.existsSync(commitSkillPath)) {
-    const templatePath = path.join(
-      parentMind, ".github", "skills", "new-mind", "templates", "commit-user-template.md"
-    );
-    fs.copyFileSync(templatePath, commitSkillPath);
-    log.push({ action: "installed", type: "skill", name: "commit" });
+  // Install upgrade skill (skip if already present)
+  const upgradeDest = path.join(userCopilotDir, "skills", "upgrade");
+  if (!fs.existsSync(path.join(upgradeDest, "SKILL.md"))) {
+    const result = installBundledUpgrade(scriptDir, upgradeDest);
+    log.push({ ...result, type: "skill" });
   } else {
-    log.push({ action: "skipped", type: "skill", name: "commit" });
+    log.push({ action: "skipped", type: "skill", name: "upgrade" });
   }
 
-  // Other skills — copy directly from parent
-  for (const skill of SKILLS_TO_COPY.filter((s) => s !== "commit")) {
-    const dest = path.join(userCopilotDir, "skills", skill, "SKILL.md");
-    if (!fs.existsSync(dest)) {
-      const src = path.join(parentMind, ".github", "skills", skill);
-      copyDirRecursive(src, path.join(userCopilotDir, "skills", skill));
-      log.push({ action: "installed", type: "skill", name: skill });
-    } else {
-      log.push({ action: "skipped", type: "skill", name: skill });
-    }
-  }
-
-  // Extensions
-  for (const ext of EXTENSIONS_TO_COPY) {
-    const dest = path.join(userCopilotDir, "extensions", ext, "extension.mjs");
-    if (!fs.existsSync(dest)) {
-      const src = path.join(parentMind, ".github", "extensions", ext);
-      copyDirRecursive(src, path.join(userCopilotDir, "extensions", ext));
-      log.push({ action: "installed", type: "extension", name: ext });
-    } else {
-      log.push({ action: "skipped", type: "extension", name: ext });
-    }
-  }
-
-  // Prompts
-  for (const prompt of PROMPTS_TO_COPY) {
-    const dest = path.join(userCopilotDir, "prompts", prompt);
-    if (!fs.existsSync(dest)) {
-      const src = path.join(parentMind, ".github", "prompts", prompt);
-      if (fs.existsSync(src)) {
-        fs.mkdirSync(path.dirname(dest), { recursive: true });
-        fs.copyFileSync(src, dest);
-        log.push({ action: "installed", type: "prompt", name: prompt });
-      }
-    } else {
-      log.push({ action: "skipped", type: "prompt", name: prompt });
-    }
-  }
-
-  // Registry
+  // Registry (skip if already present)
   const registryPath = path.join(userCopilotDir, "registry.json");
   if (!fs.existsSync(registryPath)) {
-    const registry = generateRegistryObject(parentMind, "user");
+    const registry = generateFreshRegistry("user");
     fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2) + "\n");
     log.push({ action: "installed", type: "registry", name: "registry.json" });
   } else {
@@ -814,20 +698,21 @@ function installSharedResources(parentMind, userCopilotDir) {
 function createMind(config) {
   // Expand tilde in all path fields before use
   const mindDir = config.mindDir ? expandTilde(config.mindDir) : config.mindDir;
-  const parentMind = config.parentMind ? expandTilde(config.parentMind) : config.parentMind;
   const agentName = config.agentName;
   const type = config.type;
   const expandedConfig = {
     ...config,
     mindDir,
-    parentMind,
     userCopilotDir: config.userCopilotDir ? expandTilde(config.userCopilotDir) : undefined,
   };
   const result = { files: [], warnings: [] };
 
+  // Resolve script directory for bundled resources
+  const scriptDir = config.scriptDir || path.dirname(__filename);
+
   // Validate required fields
   const required = [
-    "type", "mindDir", "agentName", "parentMind",
+    "type", "mindDir", "agentName",
     "character", "characterSource", "role", "agentDescription",
     "soulOpening", "soulMission", "soulCoreTruths", "soulBoundaries", "soulVibe",
     "agentRole", "agentMethod", "agentPrinciples",
@@ -885,22 +770,15 @@ function createMind(config) {
     { path: ".working-memory/log.md", type: "file" }
   );
 
-  // 6. Copy skills and extensions (repo only)
+  // 6. Install upgrade skill and registry (repo only)
   if (type === "repo") {
-    const skillsDest = path.join(mindDir, ".github", "skills");
-    const copiedSkills = copySkills(parentMind, skillsDest);
-    result.files.push(...copiedSkills.map((s) => ({ path: `.github/skills/${s}/`, type: "directory" })));
+    const upgradeDest = path.join(mindDir, ".github", "skills", "upgrade");
+    const upgradeResult = installBundledUpgrade(scriptDir, upgradeDest);
+    if (upgradeResult.action === "installed") {
+      result.files.push({ path: ".github/skills/upgrade/", type: "directory" });
+    }
 
-    const extDest = path.join(mindDir, ".github", "extensions");
-    const copiedExts = copyExtensions(parentMind, extDest);
-    result.files.push(...copiedExts.map((e) => ({ path: `.github/extensions/${e}/`, type: "directory" })));
-
-    const promptsDest = path.join(mindDir, ".github", "prompts");
-    const copiedPrompts = copyPrompts(parentMind, promptsDest);
-    result.files.push(...copiedPrompts.map((p) => ({ path: `.github/prompts/${p}`, type: "file" })));
-
-    // 7. Generate registry (repo)
-    const registry = generateRegistryObject(parentMind, "repo");
+    const registry = generateFreshRegistry("repo");
     fs.writeFileSync(
       path.join(mindDir, ".github", "registry.json"),
       JSON.stringify(registry, null, 2) + "\n"
@@ -908,9 +786,9 @@ function createMind(config) {
     result.files.push({ path: ".github/registry.json", type: "file" });
   }
 
-  // 8. Install shared resources (user only)
+  // 7. Install shared resources (user only)
   if (type === "user") {
-    const sharedLog = installSharedResources(parentMind, expandedConfig.userCopilotDir);
+    const sharedLog = installSharedResources(scriptDir, expandedConfig.userCopilotDir);
     result.sharedResources = sharedLog;
   }
 
@@ -935,10 +813,8 @@ module.exports = {
   generateRules,
   generateLog,
   generateMindIndex,
-  copySkills,
-  copyExtensions,
-  copyPrompts,
-  generateRegistryObject,
+  generateFreshRegistry,
+  installBundledUpgrade,
   installSharedResources,
   copyDirRecursive,
   mapPathForLayout,
@@ -947,9 +823,6 @@ module.exports = {
   COMMON_DIRS,
   REPO_DIRS,
   USER_DIRS,
-  SKILLS_TO_COPY,
-  EXTENSIONS_TO_COPY,
-  PROMPTS_TO_COPY,
   CREATIVE_BLOCK_FILES,
 };
 

--- a/.github/skills/new-mind/new-mind.test.js
+++ b/.github/skills/new-mind/new-mind.test.js
@@ -19,17 +19,14 @@ const {
   generateRules,
   generateLog,
   generateMindIndex,
-  copySkills,
-  copyExtensions,
-  generateRegistryObject,
+  generateFreshRegistry,
+  installBundledUpgrade,
   installSharedResources,
   mapPathForLayout,
   readConfigDir,
   COMMON_DIRS,
   REPO_DIRS,
   USER_DIRS,
-  SKILLS_TO_COPY,
-  EXTENSIONS_TO_COPY,
   CREATIVE_BLOCK_FILES,
   expandTilde,
 } = require("./new-mind.js");
@@ -58,52 +55,13 @@ const TEST_CONFIG_BASE = {
     "- **Test before commit.** Always.\n- **Read the diff.** Don't guess what changed.",
 };
 
-function makeTempParent() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "genesis-parent-"));
-
-  // Create a minimal parent mind with skills, extensions, and registry
-  const registry = {
-    version: "0.13.0",
-    source: "test/genesis",
-    channel: "main",
-    extensions: {
-      cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
-      canvas: { version: "0.1.3", path: ".github/extensions/canvas", description: "Canvas" },
-    },
-    skills: {
-      commit: { version: "0.1.0", path: ".github/skills/commit", description: "Commit" },
-      "daily-report": { version: "0.1.0", path: ".github/skills/daily-report", description: "Daily report" },
-      upgrade: { version: "0.4.0", path: ".github/skills/upgrade", description: "Upgrade" },
-      "new-mind": { version: "0.1.0", path: ".github/skills/new-mind", description: "New mind" },
-    },
-  };
-
-  // Registry
-  fs.mkdirSync(path.join(root, ".github"), { recursive: true });
-  fs.writeFileSync(path.join(root, ".github", "registry.json"), JSON.stringify(registry, null, 2));
-
-  // Skills with stub SKILL.md files
-  for (const skill of SKILLS_TO_COPY) {
-    const skillDir = path.join(root, ".github", "skills", skill);
-    fs.mkdirSync(skillDir, { recursive: true });
-    fs.writeFileSync(path.join(skillDir, "SKILL.md"), `# ${skill}\nStub skill.`);
-  }
-
-  // Extensions with stub extension.mjs files
-  for (const ext of EXTENSIONS_TO_COPY) {
-    const extDir = path.join(root, ".github", "extensions", ext);
-    fs.mkdirSync(extDir, { recursive: true });
-    fs.writeFileSync(path.join(extDir, "extension.mjs"), `// ${ext} stub`);
-  }
-
-  // Commit user template (needed for user minds)
-  const templateDir = path.join(root, ".github", "skills", "new-mind", "templates");
-  fs.mkdirSync(templateDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(templateDir, "commit-user-template.md"),
-    "---\nname: commit\ndescription: User-level commit skill.\n---\n# Commit (User-Level)\nStub."
-  );
-
+function makeTempSkillDir() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "skill-dir-"));
+  // Create a resources/upgrade/ directory with stub files
+  const upgradeDir = path.join(root, "resources", "upgrade");
+  fs.mkdirSync(upgradeDir, { recursive: true });
+  fs.writeFileSync(path.join(upgradeDir, "SKILL.md"), "---\nname: upgrade\ndescription: Pull updates from genesis.\n---\n# Upgrade\nStub upgrade skill.");
+  fs.writeFileSync(path.join(upgradeDir, "upgrade.js"), "// upgrade.js stub\nmodule.exports = {};");
   return root;
 }
 
@@ -131,7 +89,6 @@ describe("readConfigDir", () => {
       type: "repo",
       mindDir: "/tmp/test-mind",
       agentName: "test-bot",
-      parentMind: "/tmp/parent",
       character: "TestBot",
       characterSource: "Unit Tests",
       role: "Testing Partner",
@@ -415,7 +372,6 @@ describe("createDirectoryStructure", () => {
       for (const dir of REPO_DIRS) {
         assert.ok(fs.existsSync(path.join(root, dir)), `missing ${dir}`);
       }
-      // Should NOT have user-specific dirs
       assert.ok(!fs.existsSync(path.join(root, "domains", "minds")), "repo should not have domains/minds");
     } finally {
       cleanup(root);
@@ -432,7 +388,6 @@ describe("createDirectoryStructure", () => {
       for (const dir of USER_DIRS) {
         assert.ok(fs.existsSync(path.join(root, dir)), `missing ${dir}`);
       }
-      // Should NOT have .github/ dirs
       assert.ok(!fs.existsSync(path.join(root, ".github")), "user mind should not have .github/");
     } finally {
       cleanup(root);
@@ -498,105 +453,100 @@ describe("generateLog", () => {
   });
 });
 
-// ── Registry Tests ───────────────────────────────────────────────────────────
+// ── Fresh Registry Tests ─────────────────────────────────────────────────────
 
-describe("generateRegistryObject", () => {
-  it("reads parent registry and preserves versions", () => {
-    const parent = makeTempParent();
+describe("generateFreshRegistry", () => {
+  it("produces a registry pointing at genesis for repo layout", () => {
+    const registry = generateFreshRegistry("repo");
+    assert.equal(registry.source, "ianphil/genesis");
+    assert.equal(registry.channel, "main");
+    assert.equal(registry.version, "0.1.0");
+    assert.ok(registry.skills.upgrade, "missing upgrade skill entry");
+    assert.equal(registry.skills.upgrade.path, ".github/skills/upgrade");
+    assert.deepEqual(registry.extensions, {});
+    assert.deepEqual(registry.prompts, {});
+  });
+
+  it("uses user-layout paths for user layout", () => {
+    const registry = generateFreshRegistry("user");
+    assert.equal(registry.skills.upgrade.path, "skills/upgrade");
+  });
+
+  it("includes only upgrade skill (no commit, daily-report, etc.)", () => {
+    const registry = generateFreshRegistry("repo");
+    const skillNames = Object.keys(registry.skills);
+    assert.deepEqual(skillNames, ["upgrade"], "should contain only upgrade");
+  });
+});
+
+// ── Bundled Upgrade Tests ────────────────────────────────────────────────────
+
+describe("installBundledUpgrade", () => {
+  it("copies upgrade from resources/ to destination", () => {
+    const skillDir = makeTempSkillDir();
+    const dest = fs.mkdtempSync(path.join(os.tmpdir(), "upgrade-dest-"));
     try {
-      const registry = generateRegistryObject(parent, "repo");
-      assert.equal(registry.version, "0.13.0");
-      assert.equal(registry.source, "test/genesis");
-      assert.equal(registry.extensions.cron.version, "0.1.4");
-      assert.equal(registry.skills.commit.version, "0.1.0");
+      const result = installBundledUpgrade(skillDir, path.join(dest, "upgrade"));
+      assert.equal(result.action, "installed");
+      assert.ok(fs.existsSync(path.join(dest, "upgrade", "SKILL.md")), "missing SKILL.md");
+      assert.ok(fs.existsSync(path.join(dest, "upgrade", "upgrade.js")), "missing upgrade.js");
     } finally {
-      cleanup(parent);
+      cleanup(skillDir, dest);
     }
   });
 
-  it("keeps .github/ paths for repo layout", () => {
-    const parent = makeTempParent();
+  it("returns skipped when resources/upgrade/ is missing", () => {
+    const emptyDir = fs.mkdtempSync(path.join(os.tmpdir(), "empty-skill-"));
+    const dest = fs.mkdtempSync(path.join(os.tmpdir(), "upgrade-dest2-"));
     try {
-      const registry = generateRegistryObject(parent, "repo");
-      assert.equal(registry.extensions.cron.path, ".github/extensions/cron");
-      assert.equal(registry.skills.commit.path, ".github/skills/commit");
+      const result = installBundledUpgrade(emptyDir, path.join(dest, "upgrade"));
+      assert.equal(result.action, "skipped");
     } finally {
-      cleanup(parent);
-    }
-  });
-
-  it("strips .github/ paths for user layout", () => {
-    const parent = makeTempParent();
-    try {
-      const registry = generateRegistryObject(parent, "user");
-      assert.equal(registry.extensions.cron.path, "extensions/cron");
-      assert.equal(registry.skills.commit.path, "skills/commit");
-    } finally {
-      cleanup(parent);
+      cleanup(emptyDir, dest);
     }
   });
 });
 
-// ── Copy Operations ──────────────────────────────────────────────────────────
+// ── Mind Index Tests ─────────────────────────────────────────────────────────
 
-describe("copySkills", () => {
-  it("copies all skills from parent", () => {
-    const parent = makeTempParent();
-    const dest = fs.mkdtempSync(path.join(os.tmpdir(), "skills-dest-"));
-    try {
-      const copied = copySkills(parent, dest);
-      assert.deepEqual(copied.sort(), SKILLS_TO_COPY.slice().sort());
-      for (const skill of SKILLS_TO_COPY) {
-        assert.ok(
-          fs.existsSync(path.join(dest, skill, "SKILL.md")),
-          `missing ${skill}/SKILL.md`
-        );
-      }
-    } finally {
-      cleanup(parent, dest);
-    }
+describe("generateMindIndex", () => {
+  it("lists only upgrade skill for repo minds", () => {
+    const index = generateMindIndex({ ...TEST_CONFIG_BASE, type: "repo", mindDir: "/tmp/test" });
+    assert.ok(index.includes("upgrade"), "should mention upgrade");
+    assert.ok(index.includes("upgrade from genesis"), "should mention upgrade from genesis");
+    assert.ok(!index.includes("commit/"), "should NOT list commit");
+    assert.ok(!index.includes("daily-report/"), "should NOT list daily-report");
+    assert.ok(!index.includes("cron/"), "should NOT list cron");
+    assert.ok(!index.includes("canvas/"), "should NOT list canvas");
   });
-});
 
-describe("copyExtensions", () => {
-  it("copies all extensions from parent", () => {
-    const parent = makeTempParent();
-    const dest = fs.mkdtempSync(path.join(os.tmpdir(), "ext-dest-"));
-    try {
-      const copied = copyExtensions(parent, dest);
-      assert.deepEqual(copied.sort(), EXTENSIONS_TO_COPY.slice().sort());
-      for (const ext of EXTENSIONS_TO_COPY) {
-        assert.ok(
-          fs.existsSync(path.join(dest, ext, "extension.mjs")),
-          `missing ${ext}/extension.mjs`
-        );
-      }
-    } finally {
-      cleanup(parent, dest);
-    }
+  it("lists only upgrade skill for user minds", () => {
+    const index = generateMindIndex({ ...TEST_CONFIG_BASE, type: "user", mindDir: "/tmp/test" });
+    assert.ok(index.includes("upgrade"), "should mention upgrade");
+    assert.ok(!index.includes("commit/"), "should NOT list commit");
+    assert.ok(!index.includes("new-mind/"), "should NOT list new-mind");
   });
 });
 
 // ── E2E: Repo Mind Creation ──────────────────────────────────────────────────
 
 describe("repo mind creation", () => {
-  let parent, mindDir;
+  let skillDir, mindDir;
 
   before(() => {
-    parent = makeTempParent();
+    skillDir = makeTempSkillDir();
     mindDir = fs.mkdtempSync(path.join(os.tmpdir(), "repo-mind-"));
-    // Remove the temp dir so createMind can create it fresh
     fs.rmSync(mindDir, { recursive: true });
   });
 
-  after(() => cleanup(parent, mindDir));
+  after(() => cleanup(skillDir, mindDir));
 
-  it("creates a complete repo mind", () => {
+  it("creates a complete repo mind without parent", () => {
     const config = {
       ...TEST_CONFIG_BASE,
       type: "repo",
       mindDir,
-      parentMind: parent,
+      scriptDir: skillDir,
     };
 
     const result = createMind(config);
@@ -609,14 +559,11 @@ describe("repo mind creation", () => {
     for (const dir of REPO_DIRS) {
       assert.ok(fs.existsSync(path.join(mindDir, dir)), `missing dir: ${dir}`);
     }
-    assert.ok(!fs.existsSync(path.join(mindDir, "domains", "minds")),
-      "repo mind should NOT have domains/minds");
 
     // SOUL.md
     const soul = fs.readFileSync(path.join(mindDir, "SOUL.md"), "utf8");
     assert.ok(soul.includes("TestBot"), "SOUL.md missing character name");
     assert.ok(soul.includes("## Continuity"), "SOUL.md missing Continuity");
-    assert.ok(soul.includes("This file is yours to evolve"), "SOUL.md missing evolution clause");
 
     // Agent file
     const agentFile = path.join(mindDir, ".github", "agents", "test-bot.agent.md");
@@ -624,34 +571,33 @@ describe("repo mind creation", () => {
     const agentContent = fs.readFileSync(agentFile, "utf8");
     assert.ok(agentContent.includes("name: test-bot"), "agent file missing name");
     assert.ok(agentContent.includes("## Memory"), "agent file missing Memory section");
-    assert.ok(agentContent.includes("## Session Handover"), "agent file missing Session Handover");
 
     // copilot-instructions.md
-    const ci = path.join(mindDir, ".github", "copilot-instructions.md");
-    assert.ok(fs.existsSync(ci), "missing copilot-instructions.md");
+    assert.ok(fs.existsSync(path.join(mindDir, ".github", "copilot-instructions.md")),
+      "missing copilot-instructions.md");
 
-    // Skills
-    for (const skill of SKILLS_TO_COPY) {
-      assert.ok(
-        fs.existsSync(path.join(mindDir, ".github", "skills", skill, "SKILL.md")),
-        `missing skill: ${skill}`
-      );
-    }
+    // Only upgrade skill installed
+    assert.ok(
+      fs.existsSync(path.join(mindDir, ".github", "skills", "upgrade", "SKILL.md")),
+      "missing upgrade skill"
+    );
+    assert.ok(
+      !fs.existsSync(path.join(mindDir, ".github", "skills", "commit")),
+      "commit should NOT be installed"
+    );
+    assert.ok(
+      !fs.existsSync(path.join(mindDir, ".github", "extensions", "cron")),
+      "cron should NOT be installed"
+    );
 
-    // Extensions
-    for (const ext of EXTENSIONS_TO_COPY) {
-      assert.ok(
-        fs.existsSync(path.join(mindDir, ".github", "extensions", ext, "extension.mjs")),
-        `missing extension: ${ext}`
-      );
-    }
-
-    // Registry
+    // Fresh registry pointing at genesis
     const registryPath = path.join(mindDir, ".github", "registry.json");
     assert.ok(fs.existsSync(registryPath), "missing registry.json");
     const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
-    assert.equal(registry.version, "0.13.0");
-    assert.ok(registry.extensions.cron.path.startsWith(".github/"), "repo registry should have .github/ paths");
+    assert.equal(registry.source, "ianphil/genesis");
+    assert.equal(registry.channel, "main");
+    assert.ok(registry.skills.upgrade, "registry should have upgrade skill");
+    assert.deepEqual(registry.extensions, {}, "registry should have no extensions");
 
     // Working memory
     assert.ok(fs.existsSync(path.join(mindDir, ".working-memory", "memory.md")), "missing memory.md");
@@ -666,16 +612,16 @@ describe("repo mind creation", () => {
 // ── E2E: User Mind Creation ──────────────────────────────────────────────────
 
 describe("user mind creation", () => {
-  let parent, mindDir, userCopilotDir;
+  let skillDir, mindDir, userCopilotDir;
 
   before(() => {
-    parent = makeTempParent();
+    skillDir = makeTempSkillDir();
     mindDir = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "user-mind-")), "mind");
     userCopilotDir = fs.mkdtempSync(path.join(os.tmpdir(), "fake-copilot-"));
   });
 
   after(() => {
-    cleanup(parent, path.dirname(mindDir), userCopilotDir);
+    cleanup(skillDir, path.dirname(mindDir), userCopilotDir);
   });
 
   it("creates a complete user mind with NO .github/", () => {
@@ -683,8 +629,8 @@ describe("user mind creation", () => {
       ...TEST_CONFIG_BASE,
       type: "user",
       mindDir,
-      parentMind: parent,
       userCopilotDir,
+      scriptDir: skillDir,
     };
 
     const result = createMind(config);
@@ -708,42 +654,32 @@ describe("user mind creation", () => {
     const agentContent = fs.readFileSync(agentFile, "utf8");
     assert.ok(agentContent.includes(`MIND_HOME: ${mindDir}`), "agent file missing MIND_HOME");
     assert.ok(agentContent.includes("NON-NEGOTIABLE"), "agent file missing NON-NEGOTIABLE");
-    assert.ok(agentContent.includes(`cat ${mindDir}/SOUL.md`), "agent file missing cat SOUL.md");
 
     // NO copilot-instructions.md
     assert.ok(!fs.existsSync(path.join(mindDir, ".github", "copilot-instructions.md")),
       "user mind should NOT have copilot-instructions.md");
 
-    // Shared skills at userCopilotDir
-    for (const skill of SKILLS_TO_COPY) {
-      assert.ok(
-        fs.existsSync(path.join(userCopilotDir, "skills", skill, "SKILL.md")),
-        `missing shared skill: ${skill}`
-      );
-    }
-
-    // Commit skill should be user template, not copied from parent
-    const commitContent = fs.readFileSync(
-      path.join(userCopilotDir, "skills", "commit", "SKILL.md"), "utf8"
+    // Only upgrade skill at userCopilotDir
+    assert.ok(
+      fs.existsSync(path.join(userCopilotDir, "skills", "upgrade", "SKILL.md")),
+      "missing shared upgrade skill"
     );
-    assert.ok(commitContent.includes("User-Level"), "commit skill should be user-level template");
+    assert.ok(
+      !fs.existsSync(path.join(userCopilotDir, "skills", "commit")),
+      "commit should NOT be installed"
+    );
+    assert.ok(
+      !fs.existsSync(path.join(userCopilotDir, "extensions")),
+      "no extensions should be installed"
+    );
 
-    // Shared extensions at userCopilotDir
-    for (const ext of EXTENSIONS_TO_COPY) {
-      assert.ok(
-        fs.existsSync(path.join(userCopilotDir, "extensions", ext, "extension.mjs")),
-        `missing shared extension: ${ext}`
-      );
-    }
-
-    // Registry at userCopilotDir with user-layout paths
+    // Registry at userCopilotDir
     const registryPath = path.join(userCopilotDir, "registry.json");
     assert.ok(fs.existsSync(registryPath), "missing shared registry");
     const registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
-    assert.equal(registry.extensions.cron.path, "extensions/cron",
+    assert.equal(registry.source, "ianphil/genesis");
+    assert.equal(registry.skills.upgrade.path, "skills/upgrade",
       "user registry should NOT have .github/ prefix");
-    assert.equal(registry.skills.commit.path, "skills/commit",
-      "user registry skills should NOT have .github/ prefix");
 
     // Working memory — Mind Location section
     const memory = fs.readFileSync(path.join(mindDir, ".working-memory", "memory.md"), "utf8");
@@ -760,94 +696,42 @@ describe("user mind creation", () => {
   });
 });
 
-// ── E2E: Tilde Expansion in User Mind ────────────────────────────────────────
-
-describe("user mind creation with tilde paths", () => {
-  let parent, mindDir, realCopilotDir;
-
-  before(() => {
-    parent = makeTempParent();
-    mindDir = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "tilde-mind-")), "mind");
-    realCopilotDir = fs.mkdtempSync(path.join(os.tmpdir(), "tilde-copilot-"));
-  });
-
-  after(() => {
-    cleanup(parent, path.dirname(mindDir), realCopilotDir);
-  });
-
-  it("expands ~ in userCopilotDir and writes to correct location", () => {
-    // Simulate what the agent does: pass "~/.copilot" style path
-    // We can't actually use ~ in tests (it expands to the real home dir),
-    // so we test that expandTilde is applied by checking the function behavior
-    // and then test createMind with the tilde-prefixed path mock.
-    
-    // First verify expandTilde works on ~
-    const expanded = expandTilde("~/.copilot");
-    assert.strictEqual(expanded, path.join(os.homedir(), ".copilot"));
-
-    // For the E2E test, use the resolved path (since tilde expansion
-    // would write to the real homedir, which we don't want in tests)
-    const config = {
-      ...TEST_CONFIG_BASE,
-      type: "user",
-      mindDir,
-      parentMind: parent,
-      userCopilotDir: realCopilotDir,
-    };
-    const result = createMind(config);
-    assert.ok(!result.error, `createMind failed: ${result.error}`);
-
-    // Verify agent file is at the RESOLVED location, not a literal tilde dir
-    const agentPath = path.join(realCopilotDir, "agents", "test-bot.agent.md");
-    assert.ok(fs.existsSync(agentPath), "agent file must exist at resolved path");
-
-    // Verify NO literal tilde directory was created in the mind dir
-    assert.ok(!fs.existsSync(path.join(mindDir, "~")), "no literal ~ directory should exist in mind dir");
-  });
-});
-
 // ── Shared Resources Idempotency ─────────────────────────────────────────────
 
 describe("user shared resources idempotency", () => {
   it("does not overwrite existing resources", () => {
-    const parent = makeTempParent();
+    const skillDir = makeTempSkillDir();
     const userCopilotDir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-idem-"));
 
     try {
-      // Pre-populate with an existing commit skill
-      const commitDir = path.join(userCopilotDir, "skills", "commit");
-      fs.mkdirSync(commitDir, { recursive: true });
-      const existingContent = "# Existing commit skill — DO NOT OVERWRITE";
-      fs.writeFileSync(path.join(commitDir, "SKILL.md"), existingContent);
+      // Pre-populate with an existing upgrade skill
+      const upgradeDir = path.join(userCopilotDir, "skills", "upgrade");
+      fs.mkdirSync(upgradeDir, { recursive: true });
+      const existingContent = "# Existing upgrade skill — DO NOT OVERWRITE";
+      fs.writeFileSync(path.join(upgradeDir, "SKILL.md"), existingContent);
 
       // Pre-populate with an existing registry
       const existingRegistry = JSON.stringify({ version: "0.0.1", custom: true });
       fs.writeFileSync(path.join(userCopilotDir, "registry.json"), existingRegistry);
 
       // Run installSharedResources
-      const log = installSharedResources(parent, userCopilotDir);
+      const log = installSharedResources(skillDir, userCopilotDir);
 
-      // Commit skill should NOT be overwritten
-      const commitAfter = fs.readFileSync(path.join(commitDir, "SKILL.md"), "utf8");
-      assert.equal(commitAfter, existingContent, "existing commit skill was overwritten!");
+      // Upgrade skill should NOT be overwritten
+      const upgradeAfter = fs.readFileSync(path.join(upgradeDir, "SKILL.md"), "utf8");
+      assert.equal(upgradeAfter, existingContent, "existing upgrade skill was overwritten!");
 
       // Registry should NOT be overwritten
       const registryAfter = fs.readFileSync(path.join(userCopilotDir, "registry.json"), "utf8");
       assert.equal(registryAfter, existingRegistry, "existing registry was overwritten!");
 
-      // Other skills SHOULD be installed
-      assert.ok(
-        fs.existsSync(path.join(userCopilotDir, "skills", "daily-report", "SKILL.md")),
-        "daily-report should be installed"
-      );
-
-      // Log should show skipped for commit and registry
-      const commitLog = log.find((l) => l.name === "commit");
-      assert.equal(commitLog.action, "skipped", "commit should be skipped");
+      // Log should show skipped for both
+      const upgradeLog = log.find((l) => l.name === "upgrade");
+      assert.equal(upgradeLog.action, "skipped", "upgrade should be skipped");
       const registryLog = log.find((l) => l.name === "registry.json");
       assert.equal(registryLog.action, "skipped", "registry should be skipped");
     } finally {
-      cleanup(parent, userCopilotDir);
+      cleanup(skillDir, userCopilotDir);
     }
   });
 });
@@ -855,10 +739,10 @@ describe("user shared resources idempotency", () => {
 // ── E2E: Config Directory Mode ───────────────────────────────────────────────
 
 describe("config directory E2E", () => {
-  let parent, mindDir, configDir;
+  let skillDir, mindDir, configDir;
 
   before(() => {
-    parent = makeTempParent();
+    skillDir = makeTempSkillDir();
     mindDir = fs.mkdtempSync(path.join(os.tmpdir(), "configdir-mind-"));
     fs.rmSync(mindDir, { recursive: true });
     configDir = fs.mkdtempSync(path.join(os.tmpdir(), "mind-config-e2e-"));
@@ -870,7 +754,7 @@ describe("config directory E2E", () => {
         type: "repo",
         mindDir,
         agentName: "config-dir-bot",
-        parentMind: parent,
+        scriptDir: skillDir,
         character: "DirBot",
         characterSource: "E2E Tests",
         role: "Testing Partner",
@@ -889,7 +773,7 @@ describe("config directory E2E", () => {
     fs.writeFileSync(path.join(configDir, "agent-principles.md"), "- **Check before creating.** Always.");
   });
 
-  after(() => cleanup(parent, mindDir, configDir));
+  after(() => cleanup(skillDir, mindDir, configDir));
 
   it("creates a complete mind from config directory", () => {
     const config = readConfigDir(configDir);
@@ -925,12 +809,28 @@ describe("createMind validation", () => {
     assert.ok(result.error.includes("Missing required field"), "error should mention missing field");
   });
 
+  it("does NOT require parentMind", () => {
+    const tmpMind = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "val-test-")), "mind");
+    const skillDir = makeTempSkillDir();
+    try {
+      const result = createMind({
+        ...TEST_CONFIG_BASE,
+        type: "repo",
+        mindDir: tmpMind,
+        scriptDir: skillDir,
+      });
+      // Should succeed — parentMind is not required
+      assert.ok(!result.error, `should not fail without parentMind: ${result.error}`);
+    } finally {
+      cleanup(path.dirname(tmpMind), skillDir);
+    }
+  });
+
   it("rejects user mind without userCopilotDir", () => {
     const result = createMind({
       ...TEST_CONFIG_BASE,
       type: "user",
       mindDir: "/tmp/x",
-      parentMind: "/tmp/parent",
     });
     assert.ok(result.error, "should return error for missing userCopilotDir");
     assert.ok(result.error.includes("userCopilotDir"), "error should mention userCopilotDir");
@@ -941,88 +841,22 @@ describe("createMind validation", () => {
       ...TEST_CONFIG_BASE,
       type: "invalid",
       mindDir: "/tmp/x",
-      parentMind: "/tmp/parent",
     });
     assert.ok(result.error, "should return error for invalid type");
   });
 });
 
-// ── Upgrade Integration Tests ────────────────────────────────────────────────
+// ── Bundled Resources Existence Tests ────────────────────────────────────────
 
-describe("repo mind upgrade path", () => {
-  it("produces a registry compatible with upgrade.js diffRegistries", () => {
-    const parent = makeTempParent();
-    const mindDir = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "upgrade-repo-")), "mind");
-
-    try {
-      const result = createMind({
-        ...TEST_CONFIG_BASE,
-        type: "repo",
-        mindDir,
-        parentMind: parent,
-      });
-      assert.ok(!result.error, `createMind failed: ${result.error}`);
-
-      // Read the created registry
-      const localRegistry = JSON.parse(
-        fs.readFileSync(path.join(mindDir, ".github", "registry.json"), "utf8")
-      );
-
-      // Simulate a remote registry with a bumped version
-      const remoteRegistry = JSON.parse(JSON.stringify(localRegistry));
-      remoteRegistry.extensions.cron.version = "0.2.0";
-
-      // Use upgrade.js diffRegistries
-      const { diffRegistries } = require("../upgrade/upgrade.js");
-      const diff = diffRegistries(localRegistry, remoteRegistry);
-
-      assert.ok(diff.updated.length === 1, "should detect one updated item");
-      assert.equal(diff.updated[0].name, "cron", "updated item should be cron");
-      assert.equal(diff.updated[0].localVersion, "0.1.4");
-      assert.equal(diff.updated[0].version, "0.2.0");
-    } finally {
-      cleanup(parent, path.dirname(mindDir));
-    }
-  });
-});
-
-describe("user mind upgrade path", () => {
-  it("produces a registry compatible with upgrade.js diffRegistries", () => {
-    const parent = makeTempParent();
-    const mindDir = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "upgrade-user-")), "mind");
-    const userCopilotDir = fs.mkdtempSync(path.join(os.tmpdir(), "upgrade-copilot-"));
-
-    try {
-      const result = createMind({
-        ...TEST_CONFIG_BASE,
-        type: "user",
-        mindDir,
-        parentMind: parent,
-        userCopilotDir,
-      });
-      assert.ok(!result.error, `createMind failed: ${result.error}`);
-
-      // Read the user registry
-      const localRegistry = JSON.parse(
-        fs.readFileSync(path.join(userCopilotDir, "registry.json"), "utf8")
-      );
-
-      // Verify user-layout paths
-      assert.ok(!localRegistry.extensions.cron.path.includes(".github"),
-        "user registry should not have .github/ in paths");
-
-      // Simulate remote with a bumped skill
-      const remoteRegistry = JSON.parse(JSON.stringify(localRegistry));
-      remoteRegistry.skills.upgrade.version = "0.5.0";
-
-      const { diffRegistries } = require("../upgrade/upgrade.js");
-      const diff = diffRegistries(localRegistry, remoteRegistry);
-
-      assert.ok(diff.updated.length === 1, "should detect one updated item");
-      assert.equal(diff.updated[0].name, "upgrade");
-      assert.equal(diff.updated[0].version, "0.5.0");
-    } finally {
-      cleanup(parent, path.dirname(mindDir), userCopilotDir);
-    }
+describe("bundled resources", () => {
+  it("resources/upgrade/ directory exists in the skill", () => {
+    const skillRoot = path.join(__dirname);
+    const resourceDir = path.join(skillRoot, "resources", "upgrade");
+    assert.ok(fs.existsSync(resourceDir),
+      "resources/upgrade/ must exist in the skill directory");
+    assert.ok(fs.existsSync(path.join(resourceDir, "SKILL.md")),
+      "resources/upgrade/SKILL.md must exist");
+    assert.ok(fs.existsSync(path.join(resourceDir, "upgrade.js")),
+      "resources/upgrade/upgrade.js must exist");
   });
 });

--- a/.github/skills/new-mind/resources/upgrade/SKILL.md
+++ b/.github/skills/new-mind/resources/upgrade/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: upgrade
+description: Pull new extensions and skills from the genesis template registry. Use when user asks to "check for updates", "upgrade", "get latest extensions", or "sync from genesis".
+---
+
+# Upgrade from Genesis Registry
+
+Check the genesis template for new or updated extensions and skills, then install them.
+
+**This skill includes `upgrade.js`** ΓÇö a script that handles all registry comparison, file downloading, and installation deterministically. Your job is to run it and handle UX.
+
+## Prerequisites
+
+- `gh` CLI must be authenticated (`gh auth status`)
+- `.github/registry.json` must exist with a `source` field (e.g. `"source": "ianphil/genesis"`)
+- Optional `"branch"` field in `registry.json` to track a non-main branch (defaults to `"main"`)
+- Optional `"channel"` field in `registry.json` to select a release channel (e.g. `"main"`, `"frontier"`). Takes precedence over `"branch"`. Defaults to `"main"`.
+- If `registry.json` is missing or has no `source`, ask the user for the source repo (default: `ianphil/genesis`) and create it
+
+## Channels
+
+Genesis supports release channels for repos that publish multiple branches. The channel determines which branch's registry is used for `check` and `install`.
+
+### Switch channels
+
+```bash
+node .github/skills/upgrade/upgrade.js channel <name>
+```
+
+This:
+- Sets `"channel": "<name>"` in the local registry
+- Fetches the remote registry from the `<name>` branch
+- Returns a diff showing what items would be added or removed
+
+### Already on target channel
+
+If the agent is already on the requested channel, the output includes `"changed": false` ΓÇö no action needed.
+
+## Migrate (Channel ΓåÆ Package)
+
+When a release channel is being retired in favor of a package repo, use `migrate` to rewrite the registry:
+
+```bash
+node .github/skills/upgrade/upgrade.js migrate --source ianphil/genesis-frontier
+```
+
+This:
+- Diffs local registry against the target channel's remote (default: `main`)
+- Items not in the template get a `package` field assigned to the `--source`
+- Populates the `packages[]` array with an installed manifest
+- Switches channel to the target (default: `main`)
+- No files move, no downloads ΓÇö pure registry rewrite
+
+Options:
+- `--source <owner/repo>` (required) ΓÇö the package repo to assign non-template items to
+- `--channel <name>` (optional, default: `main`) ΓÇö the target channel to switch to
+
+After migration, `upgrade` pulls from the target channel and non-template items are managed by the packages skill.
+
+## Phase 1: Check for Updates
+
+Run the check command from the repo root:
+
+```bash
+node .github/skills/upgrade/upgrade.js check
+```
+
+This outputs JSON with the diff:
+
+```json
+{
+  "source": "ianphil/genesis",
+  "remoteVersion": "0.8.0",
+  "localVersion": "0.7.2",
+  "new": [{"name": "foo", "type": "skill", "version": "0.2.0", "description": "..."}],
+  "updated": [{"name": "daily-report", "type": "skill", "version": "0.2.0", "localVersion": "0.1.0", "description": "..."}],
+  "current": [{"name": "commit", "type": "skill", "version": "0.1.0", "description": "..."}],
+  "renamed": [{"oldName": "code-exec", "newName": "bridge", "type": "extension", "version": "0.2.0", "localVersion": "0.1.2", "description": "..."}],
+  "removed": [{"name": "tunnel", "type": "extension", "version": "0.1.0", "description": "..."}],
+  "localOnly": [{"name": "custom-tool", "type": "extension", "version": "0.1.0", "description": "..."}]
+}
+```
+
+## Phase 2: Present Results
+
+Format the JSON into a human-readable summary:
+
+```
+ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  ≡ƒôª REGISTRY UPDATE CHECK
+  Source: ianphil/genesis (remote v0.8.0)
+  Local: v0.7.2
+ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+≡ƒôª Extensions:
+  ≡ƒåò cron v0.3.0 ΓÇö Scheduled job execution
+  ≡ƒöä code-exec ΓåÆ bridge v0.2.0 ΓÇö renamed
+  ≡ƒùæ∩╕Å tunnel v0.1.0 ΓÇö removed from upstream
+
+≡ƒôä Skills:
+  Γ£à commit v0.3.0 ΓÇö up to date
+  Γ¼å∩╕Å daily-report v0.4.0 ΓÇö update available (local: v0.3.0)
+  ≡ƒåò copilot-extension v0.3.0 ΓÇö SDK reference
+
+≡ƒôî Pinned (local only):
+  ≡ƒôî custom-tool v0.1.0 ΓÇö kept locally
+
+Install all new/updated/renamed? Remove items deleted upstream? Or pick specific ones.
+```
+
+Use the `ask_user` tool to let the user select what to install and what to remove.
+
+If there are `removed` items, present them separately and explain they were deleted upstream. For each removed item, the user can either:
+- **Accept** ΓÇö the item will be deleted locally
+- **Decline** ΓÇö the item will be pinned (`local: true`) and never flagged again
+
+If everything is up to date (`new`, `updated`, and `removed` are all empty), say so and stop.
+
+## Phase 3: Install Selected Items
+
+Run the install command with a comma-separated list of selected item names:
+
+```bash
+node .github/skills/upgrade/upgrade.js install cron,daily-report,copilot-extension
+```
+
+This:
+- Fetches the full file tree from the remote repo (single API call)
+- Downloads and writes every file for each selected item
+- Runs `npm install --production` if a `package.json` exists in the item's path
+- Updates `.github/registry.json` with new versions
+
+Output JSON:
+
+```json
+{
+  "installed": [{"name": "cron", "type": "extension", "version": "0.3.0", "files": 14, "npmInstalled": true}],
+  "updated": [{"name": "daily-report", "type": "skill", "version": "0.4.0", "files": 1, "from": "0.3.0"}],
+  "errors": [],
+  "registryUpdated": true
+}
+```
+
+Items with `renamedFrom` indicate a rename was processed ΓÇö the old directory was removed and the old registry entry deleted.
+
+## Phase 3b: Remove Selected Items
+
+For items the user accepted for removal, run:
+
+```bash
+node .github/skills/upgrade/upgrade.js remove tunnel,old-skill
+```
+
+This:
+- Looks up each name in the local registry (extensions and skills)
+- Deletes the directory from disk
+- Removes the entry from `.github/registry.json`
+
+Output JSON:
+
+```json
+{
+  "removed": [{"name": "tunnel", "type": "extension", "version": "0.1.0", "path": ".github/extensions/tunnel"}],
+  "errors": [],
+  "registryUpdated": true
+}
+```
+
+## Phase 3c: Pin Declined Removals
+
+For removed items the user chose to **keep**, pin them so they won't be flagged again:
+
+```bash
+node .github/skills/upgrade/upgrade.js pin tunnel
+```
+
+This sets `"local": true` on the item in `.github/registry.json`. Future `check` runs will list it under `localOnly` instead of `removed`.
+
+Output JSON:
+
+```json
+{
+  "pinned": [{"name": "tunnel", "type": "extension", "version": "0.1.0"}],
+  "errors": []
+}
+```
+
+## Phase 4: Summary
+
+Format the install results:
+
+```
+ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+  Γ£à UPGRADE COMPLETE
+ΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉΓòÉ
+
+Installed:
+  ≡ƒôª cron v0.3.0 ΓÇö 14 files, npm installed
+  ≡ƒôä copilot-extension v0.3.0 ΓÇö 1 file
+
+Updated:
+  ≡ƒôä daily-report v0.3.0 ΓåÆ v0.4.0 ΓÇö 1 file
+
+Renamed:
+  ≡ƒöä code-exec ΓåÆ bridge v0.2.0 ΓÇö 9 files, old directory removed
+
+Local registry updated to v0.8.0.
+```
+
+If any items were removed:
+```
+Removed:
+  ≡ƒùæ∩╕Å tunnel v0.1.0 ΓÇö directory deleted
+
+Pinned (kept locally):
+  ≡ƒôî old-tool v0.1.0 ΓÇö will not be flagged again
+```
+
+If any extensions were installed or updated, remind the user:
+> "New extensions installed. Restart your Copilot session to activate them, or I can reload extensions now."
+
+If there are errors in the output, report them clearly and suggest retrying individual items.
+
+## Rules
+
+- **Never delete pinned (local-only) items** ΓÇö items with `local: true` are preserved and skipped during removal checks
+- **Never modify files outside of `.github/extensions/` and `.github/skills/`** ΓÇö the script only touches these paths
+- **Always show the diff before installing or removing** ΓÇö never auto-install or auto-remove without user confirmation
+- **Removals are destructive** ΓÇö they delete the directory from disk. Always confirm with the user before removing
+- **Declined removals get pinned** ΓÇö if the user declines a removal, pin it with `upgrade.js pin` so it won't be flagged again
+- **Renames are destructive** ΓÇö they delete the old directory. Always confirm with the user before installing a renamed item
+- **Old names auto-resolve** ΓÇö if a user requests an old name (e.g. `code-exec`), the script resolves it to the new name via the `renames` map
+- **Channel is sticky** ΓÇö once set via `channel` command, all future `check` and `install` calls use it. The `channel` field takes precedence over `branch`.
+- **Channel switching is non-destructive** ΓÇö it updates the registry and shows a diff. The user must explicitly `install` or `remove` items.
+- **Skip items the user doesn't select** ΓÇö respect their choices
+- **If `gh` CLI is not available**, report the error and stop ΓÇö the script requires it
+- **If the script fails**, show the error output and suggest checking `gh auth status`

--- a/.github/skills/new-mind/resources/upgrade/upgrade.js
+++ b/.github/skills/new-mind/resources/upgrade/upgrade.js
@@ -1,0 +1,824 @@
+#!/usr/bin/env node
+// upgrade.js ΓÇö Deterministic upgrade script for genesis-based agents.
+// Zero dependencies. Requires: Node.js 18+, gh CLI authenticated.
+//
+// Usage:
+//   node upgrade.js check              ΓÇö compare local vs remote registry
+//   node upgrade.js install name1,name2 ΓÇö install/update selected items
+//   node upgrade.js remove name1,name2  ΓÇö remove selected items from local
+//   node upgrade.js pin name1,name2     ΓÇö pin items to prevent removal
+//   node upgrade.js channel <name>      ΓÇö switch release channel (e.g. main, frontier)
+//   node upgrade.js migrate --source <owner/repo> [--channel <name>]
+//                                        ΓÇö rewrite registry: assign non-template items to a package source
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// ΓöÇΓöÇ Helpers ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+function gh(apiPath) {
+  const raw = execSync(`gh api ${apiPath}`, {
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return JSON.parse(raw);
+}
+
+function ghBlob(owner, repo, sha) {
+  const blob = gh(`/repos/${owner}/${repo}/git/blobs/${sha}`);
+  return Buffer.from(blob.content, "base64");
+}
+
+function compareSemver(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return 1;
+    if ((pa[i] || 0) < (pb[i] || 0)) return -1;
+  }
+  return 0;
+}
+
+function findRepoRoot() {
+  let dir = process.cwd();
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, ".github", "registry.json"))) return dir;
+    dir = path.dirname(dir);
+  }
+  // User-level layout: registry.json at CWD (e.g. ~/.copilot/)
+  if (fs.existsSync(path.join(process.cwd(), "registry.json"))) {
+    return process.cwd();
+  }
+  // Fallback: cwd
+  return process.cwd();
+}
+
+function detectLayout(root) {
+  if (fs.existsSync(path.join(root, ".github", "registry.json"))) return "repo";
+  if (fs.existsSync(path.join(root, "registry.json"))) return "user";
+  return "repo";
+}
+
+function registryPath(root) {
+  return detectLayout(root) === "user"
+    ? path.join(root, "registry.json")
+    : path.join(root, ".github", "registry.json");
+}
+
+function mapPathToLocal(remotePath, layout) {
+  if (layout === "user") {
+    return remotePath.replace(/^\.github\//, "");
+  }
+  return remotePath;
+}
+
+function readLocalRegistry(root) {
+  const p = registryPath(root);
+  if (!fs.existsSync(p)) {
+    return { version: "0.0.0", source: "", extensions: {}, skills: {} };
+  }
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+function writeLocalRegistry(root, registry) {
+  const p = registryPath(root);
+  fs.writeFileSync(p, JSON.stringify(registry, null, 2) + "\n", "utf8");
+}
+
+function makeStagedRemovalPath(itemDir) {
+  const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return path.join(
+    path.dirname(itemDir),
+    `${path.basename(itemDir)}.remove-${suffix}`
+  );
+}
+
+function resolveChannel(local) {
+  return local.channel || local.branch || "main";
+}
+
+function parseSource(source) {
+  const parts = source.split("/");
+  return { owner: parts[0], repo: parts[1] };
+}
+
+// ΓöÇΓöÇ Pure logic (testable) ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+function diffRegistries(local, remote) {
+  const result = {
+    source: local.source,
+    remoteVersion: remote.version,
+    localVersion: local.version,
+    new: [],
+    updated: [],
+    current: [],
+    renamed: [],
+    removed: [],
+    localOnly: [],
+    promoted: [],
+  };
+
+  // Build rename lookup: oldName ΓåÆ newName, newName ΓåÆ oldName
+  const renames = remote.renames || {};
+  const reverseRenames = {};
+  for (const [oldName, newName] of Object.entries(renames)) {
+    reverseRenames[newName] = oldName;
+  }
+
+  // Compare both extensions and skills
+  for (const type of ["extensions", "skills"]) {
+    const remoteItems = remote[type] || {};
+    const localItems = local[type] || {};
+    const typeSingular = type === "extensions" ? "extension" : "skill";
+
+    for (const [name, info] of Object.entries(remoteItems)) {
+      const item = {
+        name,
+        type: typeSingular,
+        version: info.version,
+        path: info.path,
+        description: info.description,
+      };
+
+      if (name in localItems) {
+        if (localItems[name].package) {
+          // Template now owns this item ΓÇö it was previously installed via a package
+          result.promoted.push({
+            ...item,
+            package: localItems[name].package,
+            localVersion: localItems[name].version,
+          });
+        } else if (compareSemver(info.version, localItems[name].version) > 0) {
+          result.updated.push({
+            ...item,
+            localVersion: localItems[name].version,
+          });
+        } else {
+          result.current.push(item);
+        }
+      } else {
+        // Not installed under this name ΓÇö check if it's a rename
+        const oldName = reverseRenames[name];
+        if (oldName && oldName in localItems) {
+          result.renamed.push({
+            oldName,
+            newName: name,
+            type: typeSingular,
+            version: info.version,
+            localVersion: localItems[oldName].version,
+            description: info.description,
+          });
+        } else {
+          result.new.push(item);
+        }
+      }
+    }
+
+    for (const [name, info] of Object.entries(localItems)) {
+      if (!(name in remoteItems)) {
+        // Skip if this is the old name of a rename (already reported above)
+        if (name in renames) continue;
+
+        const item = {
+          name,
+          type: typeSingular,
+          version: info.version,
+          path: info.path,
+          description: info.description,
+        };
+
+        // Pinned items go to localOnly; unpinned go to removed
+        if (info.local) {
+          result.localOnly.push(item);
+        } else if (info.package) {
+          // Package-installed items not in template are kept (managed by packages skill)
+          result.localOnly.push(item);
+        } else {
+          result.removed.push(item);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+// ΓöÇΓöÇ Check command ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+function check() {
+  const root = findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  if (!local.source) {
+    console.error(
+      JSON.stringify({ error: "No source configured in local registry" })
+    );
+    process.exit(1);
+  }
+
+  const { owner, repo } = parseSource(local.source);
+  const branch = resolveChannel(local);
+
+  // Fetch remote registry
+  const remoteRaw = gh(
+    `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${branch}`
+  );
+  const remote = JSON.parse(
+    Buffer.from(remoteRaw.content, "base64").toString("utf8")
+  );
+
+  const result = diffRegistries(local, remote);
+  result.channel = branch;
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ΓöÇΓöÇ Install command ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+function install(names) {
+  const root = findRepoRoot();
+  const layout = detectLayout(root);
+  const local = readLocalRegistry(root);
+  const { owner, repo } = parseSource(local.source);
+  const branch = resolveChannel(local);
+
+  // Fetch remote registry
+  const remoteRaw = gh(
+    `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${branch}`
+  );
+  const remote = JSON.parse(
+    Buffer.from(remoteRaw.content, "base64").toString("utf8")
+  );
+
+  // Fetch full tree once
+  const tree = gh(`/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`);
+  const treeMap = new Map();
+  for (const entry of tree.tree) {
+    if (entry.type === "blob") {
+      treeMap.set(entry.path, entry.sha);
+    }
+  }
+
+  const result = {
+    installed: [],
+    updated: [],
+    promoted: [],
+    errors: [],
+    registryUpdated: false,
+  };
+
+  const requestedNames = new Set(names);
+
+  // Build rename lookup and resolve old names to new names
+  const renames = remote.renames || {};
+  const reverseRenames = {};
+  for (const [oldName, newName] of Object.entries(renames)) {
+    reverseRenames[newName] = oldName;
+    if (requestedNames.has(oldName)) {
+      requestedNames.delete(oldName);
+      requestedNames.add(newName);
+    }
+  }
+
+  for (const type of ["extensions", "skills"]) {
+    const remoteItems = remote[type] || {};
+    const localItems = local[type] || {};
+
+    for (const [name, info] of Object.entries(remoteItems)) {
+      if (!requestedNames.has(name)) continue;
+
+      const isNew = !(name in localItems);
+      const itemPath = info.path; // remote path for tree matching (e.g. ".github/extensions/cron")
+      const localItemPath = mapPathToLocal(itemPath, layout);
+
+      try {
+        // Find all files under this item's path in the tree
+        const prefix = itemPath.endsWith("/") ? itemPath : itemPath + "/";
+        const files = [];
+        for (const [filePath, sha] of treeMap) {
+          if (filePath.startsWith(prefix) || filePath === itemPath) {
+            files.push({ path: filePath, sha });
+          }
+        }
+
+        if (files.length === 0) {
+          result.errors.push({
+            name,
+            error: `No files found in tree under ${itemPath}`,
+          });
+          continue;
+        }
+
+        // Download and write each file
+        let fileCount = 0;
+        for (const file of files) {
+          const content = ghBlob(owner, repo, file.sha);
+          const localPath = path.join(root, mapPathToLocal(file.path, layout));
+          const dir = path.dirname(localPath);
+
+          fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync(localPath, content);
+          fileCount++;
+        }
+
+        // Run npm install if package.json exists
+        const pkgPath = path.join(root, localItemPath, "package.json");
+        let npmInstalled = false;
+        if (fs.existsSync(pkgPath)) {
+          try {
+            execSync("npm install --production", {
+              cwd: path.join(root, localItemPath),
+              encoding: "utf8",
+              stdio: "pipe",
+            });
+            npmInstalled = true;
+          } catch (e) {
+            result.errors.push({
+              name,
+              error: `npm install failed: ${e.message.slice(0, 200)}`,
+            });
+          }
+        }
+
+        // Update local registry ΓÇö remove package field if promoting
+        if (!local[type]) local[type] = {};
+        const wasPackage = localItems[name] && localItems[name].package;
+        local[type][name] = {
+          version: info.version,
+          path: localItemPath,
+          description: info.description,
+        };
+
+        const entry = {
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+          files: fileCount,
+          npmInstalled,
+        };
+
+        // Handle promotion ΓÇö clean up package tracking
+        if (wasPackage) {
+          const pkgSource = localItems[name].package;
+          entry.promotedFrom = pkgSource;
+          if (Array.isArray(local.packages)) {
+            for (const pkg of local.packages) {
+              if (pkg.source === pkgSource && pkg.installed) {
+                const pkgType = pkg.installed[type];
+                if (pkgType && pkgType[name]) {
+                  delete pkgType[name];
+                }
+              }
+            }
+            // Remove empty package entries
+            local.packages = local.packages.filter((pkg) => {
+              if (!pkg.installed) return false;
+              const exts = Object.keys(pkg.installed.extensions || {});
+              const skills = Object.keys(pkg.installed.skills || {});
+              return exts.length > 0 || skills.length > 0;
+            });
+          }
+          result.promoted.push(entry);
+        } else if (isNew) {
+          result.installed.push(entry);
+        } else {
+          result.updated.push({
+            ...entry,
+            from: localItems[name].version,
+          });
+        }
+
+        // Handle rename ΓÇö clean up old directory and registry entry
+        const oldName = reverseRenames[name];
+        if (oldName) {
+          for (const t of ["extensions", "skills"]) {
+            if (local[t] && local[t][oldName]) {
+              const oldDir = path.join(root, local[t][oldName].path);
+              if (fs.existsSync(oldDir)) {
+                fs.rmSync(oldDir, { recursive: true, force: true });
+              }
+              delete local[t][oldName];
+              break;
+            }
+          }
+          entry.renamedFrom = oldName;
+        }
+
+        if (isNew) {
+          result.installed.push(entry);
+        } else {
+          result.updated.push({
+            ...entry,
+            from: localItems[name].version,
+          });
+        }
+      } catch (e) {
+        result.errors.push({
+          name,
+          error: e.message.slice(0, 300),
+        });
+      }
+    }
+  }
+
+  // Update registry version and write
+  if (result.installed.length > 0 || result.updated.length > 0 || result.promoted.length > 0) {
+    local.version = remote.version;
+    writeLocalRegistry(root, local);
+    result.registryUpdated = true;
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ΓöÇΓöÇ Remove command ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+function remove(names, root) {
+  root = root || findRepoRoot();
+  const local = readLocalRegistry(root);
+  const pendingRemovals = [];
+
+  const result = {
+    removed: [],
+    errors: [],
+    registryUpdated: false,
+  };
+
+  for (const name of names) {
+    let found = false;
+
+    for (const type of ["extensions", "skills"]) {
+      const items = local[type] || {};
+      if (!(name in items)) continue;
+
+      found = true;
+      const info = items[name];
+      const itemDir = path.join(root, info.path);
+      let stagedDir = null;
+
+      try {
+        if (fs.existsSync(itemDir)) {
+          stagedDir = makeStagedRemovalPath(itemDir);
+          fs.renameSync(itemDir, stagedDir);
+        }
+
+        delete local[type][name];
+        pendingRemovals.push({
+          name,
+          info,
+          type,
+          itemDir,
+          stagedDir,
+        });
+      } catch (e) {
+        if (stagedDir && fs.existsSync(stagedDir)) {
+          fs.renameSync(stagedDir, itemDir);
+        }
+        result.errors.push({
+          name,
+          error: e.message.slice(0, 300),
+        });
+      }
+      break;
+    }
+
+    if (!found) {
+      result.errors.push({
+        name,
+        error: "Not found in local registry (extensions or skills)",
+      });
+    }
+  }
+
+  if (pendingRemovals.length > 0) {
+    try {
+      writeLocalRegistry(root, local);
+      result.registryUpdated = true;
+
+      for (const item of pendingRemovals) {
+        if (item.stagedDir && fs.existsSync(item.stagedDir)) {
+          fs.rmSync(item.stagedDir, { recursive: true, force: true });
+        }
+
+        result.removed.push({
+          name: item.name,
+          type: item.type === "extensions" ? "extension" : "skill",
+          version: item.info.version,
+          path: item.info.path,
+        });
+      }
+    } catch (e) {
+      for (let i = pendingRemovals.length - 1; i >= 0; i--) {
+        const item = pendingRemovals[i];
+        local[item.type][item.name] = item.info;
+
+        if (item.stagedDir && fs.existsSync(item.stagedDir)) {
+          fs.renameSync(item.stagedDir, item.itemDir);
+        }
+
+        result.errors.push({
+          name: item.name,
+          error: `Failed to update registry: ${e.message.slice(0, 300)}`,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+// ΓöÇΓöÇ Pin command ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+function pin(names, root) {
+  root = root || findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  const result = {
+    pinned: [],
+    errors: [],
+  };
+
+  for (const name of names) {
+    let found = false;
+
+    for (const type of ["extensions", "skills"]) {
+      const items = local[type] || {};
+      if (!(name in items)) continue;
+
+      found = true;
+      items[name].local = true;
+
+      result.pinned.push({
+        name,
+        type: type === "extensions" ? "extension" : "skill",
+        version: items[name].version,
+      });
+      break;
+    }
+
+    if (!found) {
+      result.errors.push({
+        name,
+        error: "Not found in local registry (extensions or skills)",
+      });
+    }
+  }
+
+  if (result.pinned.length > 0) {
+    writeLocalRegistry(root, local);
+  }
+
+  return result;
+}
+
+// ΓöÇΓöÇ Channel command ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+function channel(name) {
+  const root = findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  if (!local.source) {
+    console.error(
+      JSON.stringify({ error: "No source configured in local registry" })
+    );
+    process.exit(1);
+  }
+
+  const previous = resolveChannel(local);
+
+  if (name === previous) {
+    console.log(
+      JSON.stringify({
+        channel: name,
+        changed: false,
+        message: `Already on channel "${name}".`,
+      })
+    );
+    return;
+  }
+
+  const { owner, repo } = parseSource(local.source);
+
+  // Fetch remote registry from the target channel branch
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${name}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        error: `Failed to fetch registry from channel "${name}". Does the branch exist? ${e.message.slice(0, 200)}`,
+      })
+    );
+    process.exit(1);
+  }
+
+  // Update the channel in local registry
+  local.channel = name;
+  delete local.branch; // channel supersedes branch
+  writeLocalRegistry(root, local);
+
+  // Diff against the target channel's registry
+  const diff = diffRegistries(local, remote);
+  diff.channel = name;
+  diff.previousChannel = previous;
+  diff.changed = true;
+
+  console.log(JSON.stringify(diff, null, 2));
+}
+
+// ΓöÇΓöÇ Migrate command ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+function migrateRegistry(local, remote, source) {
+  const migrated = [];
+  const skipped = [];
+
+  // For each local item NOT in the target channel's registry, assign it to the package source
+  for (const type of ["extensions", "skills"]) {
+    const remoteItems = remote[type] || {};
+    const localItems = local[type] || {};
+
+    for (const [name, info] of Object.entries(localItems)) {
+      if (name in remoteItems) {
+        skipped.push({ name, type: type === "extensions" ? "extension" : "skill", reason: "in_template" });
+        continue;
+      }
+      if (info.local) {
+        skipped.push({ name, type: type === "extensions" ? "extension" : "skill", reason: "pinned" });
+        continue;
+      }
+      if (info.package) {
+        skipped.push({ name, type: type === "extensions" ? "extension" : "skill", reason: "already_package" });
+        continue;
+      }
+
+      // Assign to package
+      local[type][name] = { ...info, package: source };
+      migrated.push({
+        name,
+        type: type === "extensions" ? "extension" : "skill",
+        version: info.version,
+      });
+    }
+  }
+
+  // Build the packages[] entry for migrated items
+  if (migrated.length > 0) {
+    if (!local.packages) local.packages = [];
+
+    let pkgEntry = local.packages.find((p) => p.source === source);
+    if (!pkgEntry) {
+      pkgEntry = { source, ref: "main", installed: { extensions: {}, skills: {} } };
+      local.packages.push(pkgEntry);
+    }
+    if (!pkgEntry.installed) pkgEntry.installed = { extensions: {}, skills: {} };
+
+    for (const item of migrated) {
+      const type = item.type === "extension" ? "extensions" : "skills";
+      const info = local[type][item.name];
+      pkgEntry.installed[type][item.name] = {
+        version: info.version,
+        path: info.path,
+        description: info.description,
+      };
+    }
+  }
+
+  return { migrated, skipped };
+}
+
+function migrate(source, targetChannel) {
+  const root = findRepoRoot();
+  const local = readLocalRegistry(root);
+  const currentChannel = resolveChannel(local);
+
+  if (!local.source) {
+    return { error: "No source configured in local registry" };
+  }
+
+  const { owner, repo } = parseSource(local.source);
+
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${targetChannel}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    return {
+      error: `Failed to fetch registry from channel "${targetChannel}". ${e.message.slice(0, 200)}`,
+    };
+  }
+
+  const { migrated, skipped } = migrateRegistry(local, remote, source);
+
+  // Switch channel to target
+  local.channel = targetChannel;
+  delete local.branch;
+
+  writeLocalRegistry(root, local);
+
+  return {
+    source,
+    targetChannel,
+    previousChannel: currentChannel,
+    migrated,
+    skipped,
+    registryUpdated: true,
+  };
+}
+
+// ΓöÇΓöÇ Exports (for testing) ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+module.exports = { compareSemver, diffRegistries, remove, pin, resolveChannel, detectLayout, mapPathToLocal, migrate, migrateRegistry };
+
+// ΓöÇΓöÇ CLI entry ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
+
+if (require.main === module) {
+  const [, , command, ...args] = process.argv;
+
+  switch (command) {
+    case "check":
+      check();
+      break;
+    case "install":
+      if (!args[0]) {
+        console.error(
+          JSON.stringify({
+            error: "Usage: node upgrade.js install name1,name2,...",
+          })
+        );
+        process.exit(1);
+      }
+      install(args[0].split(",").map((s) => s.trim()));
+      break;
+    case "remove":
+      if (!args[0]) {
+        console.error(
+          JSON.stringify({
+            error: "Usage: node upgrade.js remove name1,name2,...",
+          })
+        );
+        process.exit(1);
+      }
+      console.log(JSON.stringify(remove(args[0].split(",").map((s) => s.trim())), null, 2));
+      break;
+    case "pin":
+      if (!args[0]) {
+        console.error(
+          JSON.stringify({
+            error: "Usage: node upgrade.js pin name1,name2,...",
+          })
+        );
+        process.exit(1);
+      }
+      console.log(JSON.stringify(pin(args[0].split(",").map((s) => s.trim())), null, 2));
+      break;
+    case "channel":
+      if (!args[0]) {
+        console.error(
+          JSON.stringify({
+            error: 'Usage: node upgrade.js channel <name> (e.g. "main", "frontier")',
+          })
+        );
+        process.exit(1);
+      }
+      channel(args[0].trim());
+      break;
+    case "migrate": {
+      // Parse --source and --channel flags
+      let source = null;
+      let targetChannel = "main";
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === "--source" && args[i + 1]) {
+          source = args[++i].trim();
+        } else if (args[i] === "--channel" && args[i + 1]) {
+          targetChannel = args[++i].trim();
+        }
+      }
+      if (!source) {
+        console.error(
+          JSON.stringify({
+            error: 'Usage: node upgrade.js migrate --source <owner/repo> [--channel <name>]',
+          })
+        );
+        process.exit(1);
+      }
+      console.log(JSON.stringify(migrate(source, targetChannel), null, 2));
+      break;
+    }
+    default:
+      console.error(
+        JSON.stringify({
+          error: `Unknown command: ${command}. Use "check", "install", "remove", "pin", "channel", or "migrate".`,
+        })
+      );
+      process.exit(1);
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: parentMind removed. New minds bootstrap with upgrade skill only + registry pointing at ianphil/genesis. Run 'upgrade from genesis' for full toolkit. 58 tests pass. Version 0.2.0->0.3.0.