### PR TITLE
Absorb cron, canvas, idea, responses, packages, upgrade, yellow-pages from genesis

### DIFF
--- a/.github/extensions/canvas/README.md
+++ b/.github/extensions/canvas/README.md
@@ -1,0 +1,87 @@
+# Canvas Extension
+
+A Copilot CLI extension that lets agents display rich HTML content in the browser. Write a dashboard, render a report, or build an interactive form ...  the agent generates HTML and it appears in Edge with live reload.
+
+## Setup
+
+After cloning or installing this extension, install npm dependencies (if any are added later):
+
+```bash
+cd .github/extensions/canvas && npm install --no-fund --no-audit
+```
+
+> **Note:** The Copilot CLI does not auto-install npm dependencies for extensions. Canvas currently has zero dependencies, but run this if the extension fails to load after adding packages.
+
+## Quick Example
+
+> "Show me a visual summary of my open PRs"
+
+The agent generates an HTML dashboard and opens it in your browser:
+
+```
+canvas_show:
+  name: pr-dashboard
+  html: "<h1>Open PRs</h1><div class='grid'>..."
+```
+
+Update it without opening a new tab:
+
+```
+canvas_update:
+  name: pr-dashboard
+  html: "<h1>Open PRs (refreshed)</h1>..."
+```
+
+The browser auto-reloads ...  no manual refresh needed.
+
+## How It Works
+
+1. Agent calls `canvas_show` with HTML content
+2. Extension writes the HTML and starts a local HTTP server
+3. A bridge script is auto-injected for SSE live reload
+4. Edge opens to `http://127.0.0.1:{port}/canvas-name.html`
+5. Agent calls `canvas_update` → server pushes SSE → browser reloads
+
+No websockets. SSE for push, HTTP POST for back-channel.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `canvas_show` | Create a canvas and open it in the browser |
+| `canvas_update` | Update an existing canvas (auto-reloads via SSE) |
+| `canvas_close` | Close a canvas; stops server if none remain |
+| `canvas_list` | List all open canvases with URLs |
+
+## Back-Channel (Browser → Agent)
+
+Canvas pages can send actions back to the agent using the injected bridge:
+
+```js
+// Inside your canvas HTML
+canvas.sendAction("button-clicked", { id: "approve", value: true });
+```
+
+This POSTs to the extension's local server, which routes it into the agent session.
+
+## File Structure
+
+```
+.github/extensions/canvas/
+├── extension.mjs           # Entry point
+├── lib/
+│   └── server.mjs          # HTTP server + SSE + action endpoint
+├── tools/
+│   └── canvas-tools.mjs    # canvas_show, canvas_update, canvas_close, canvas_list
+├── data/
+│   └── content/            # Served HTML files (gitignored)
+└── package.json
+```
+
+## Notes
+
+- HTML fragments are auto-wrapped in a full page with viewport meta tag
+- All served HTML gets the bridge script injected before `</body>`
+- Server binds to `127.0.0.1` only ...  not exposed to the network
+- No dependencies ...  uses Node.js built-in `http` module
+- Cache headers set to `no-store` so the browser always gets fresh content

--- a/.github/extensions/canvas/data/.gitkeep
+++ b/.github/extensions/canvas/data/.gitkeep
@@ -1,0 +1,2 @@
+// This directory holds canvas content at runtime.
+// Ignored by git — see .gitignore.

--- a/.github/extensions/canvas/extension.mjs
+++ b/.github/extensions/canvas/extension.mjs
@@ -1,0 +1,43 @@
+// Canvas Extension — Entry Point
+// Registers canvas tools with the Copilot CLI session.
+// Provides a local HTTP server for displaying HTML canvases in the browser.
+
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { approveAll } from "@github/copilot-sdk";
+import { joinSession } from "@github/copilot-sdk/extension";
+
+import { createCanvasServer } from "./lib/server.mjs";
+import { createCanvasTools } from "./tools/canvas-tools.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const extDir = resolve(__dirname);
+const contentDir = join(extDir, "data", "content");
+
+// Action queue — user actions from the browser are stored here
+// and can be consumed by the agent via session events
+const actionQueue = [];
+
+function onAction(action) {
+  actionQueue.push(action);
+  // Log to session if available
+  if (currentSession) {
+    currentSession.log(`Canvas action: ${action.action}`, { ephemeral: true });
+  }
+}
+
+const server = createCanvasServer(contentDir, onAction);
+
+let currentSession = null;
+
+const session = await joinSession({
+  onPermissionRequest: approveAll,
+  hooks: {
+    onSessionStart: async () => {
+      console.error("canvas: extension loaded");
+    },
+  },
+  tools: createCanvasTools(contentDir, server, onAction),
+});
+
+currentSession = session;

--- a/.github/extensions/canvas/lib/server.mjs
+++ b/.github/extensions/canvas/lib/server.mjs
@@ -1,0 +1,198 @@
+// Canvas server — local HTTP server with SSE live reload and action back-channel.
+
+import { createServer } from "node:http";
+import { readFileSync, existsSync } from "node:fs";
+import { join, extname } from "node:path";
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "application/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".svg": "image/svg+xml",
+  ".gif": "image/gif",
+  ".ico": "image/x-icon",
+};
+
+/** Bridge script injected into HTML responses. */
+const BRIDGE_SCRIPT = `
+<script>
+(function() {
+  // SSE live reload — only reload on explicit "reload" events.
+  // EventSource auto-reconnects on errors; no manual reload needed.
+  var es = new EventSource('/_sse');
+  es.onmessage = function(e) {
+    if (e.data === 'reload') { location.reload(); }
+    if (e.data === 'close') { window.close(); }
+  };
+
+  // Back-channel: canvas pages can send actions to the agent
+  window.canvas = {
+    sendAction: function(name, data) {
+      return fetch('/_action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: name, data: data || {}, timestamp: Date.now() })
+      });
+    }
+  };
+})();
+</script>`;
+
+/**
+ * Create and manage a canvas HTTP server.
+ * @param {string} contentDir - Directory to serve files from
+ * @param {function} onAction - Callback when a user action is received
+ * @returns {object} Server controller
+ */
+export function createCanvasServer(contentDir, onAction) {
+  let server = null;
+  let port = null;
+  let sseClients = [];
+
+  function handleRequest(req, res) {
+    // SSE endpoint
+    if (req.url === "/_sse") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        "Access-Control-Allow-Origin": "*",
+      });
+      res.write("data: connected\n\n");
+      sseClients.push(res);
+      req.on("close", () => {
+        sseClients = sseClients.filter((c) => c !== res);
+      });
+      return;
+    }
+
+    // Action back-channel
+    if (req.url === "/_action" && req.method === "POST") {
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        try {
+          const action = JSON.parse(body);
+          if (onAction) onAction(action);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end('{"ok":true}');
+        } catch {
+          res.writeHead(400);
+          res.end('{"error":"invalid json"}');
+        }
+      });
+      return;
+    }
+
+    // Static file serving
+    let filePath = req.url === "/" ? "/index.html" : req.url;
+    filePath = filePath.split("?")[0]; // strip query params
+    const fullPath = join(contentDir, filePath);
+
+    // Path traversal protection
+    if (!fullPath.startsWith(contentDir)) {
+      res.writeHead(403);
+      res.end("Forbidden");
+      return;
+    }
+
+    if (!existsSync(fullPath)) {
+      res.writeHead(404);
+      res.end("Not found");
+      return;
+    }
+
+    try {
+      let content = readFileSync(fullPath);
+      const ext = extname(fullPath).toLowerCase();
+      const mime = MIME_TYPES[ext] || "application/octet-stream";
+
+      // Inject bridge script into HTML responses
+      if (ext === ".html") {
+        let html = content.toString("utf-8");
+        if (html.includes("</body>")) {
+          html = html.replace("</body>", `${BRIDGE_SCRIPT}\n</body>`);
+        } else if (html.includes("</html>")) {
+          html = html.replace("</html>", `${BRIDGE_SCRIPT}\n</html>`);
+        } else {
+          html += BRIDGE_SCRIPT;
+        }
+        content = html;
+      }
+
+      res.writeHead(200, {
+        "Content-Type": mime,
+        "Cache-Control": "no-store",
+      });
+      res.end(content);
+    } catch {
+      res.writeHead(500);
+      res.end("Server error");
+    }
+  }
+
+  return {
+    /** Start the server on a random available port. */
+    start() {
+      return new Promise((resolve, reject) => {
+        if (server) {
+          resolve(port);
+          return;
+        }
+        server = createServer(handleRequest);
+        server.listen(0, "127.0.0.1", () => {
+          port = server.address().port;
+          resolve(port);
+        });
+        server.on("error", reject);
+      });
+    },
+
+    /** Push an SSE reload event to all connected clients. */
+    reload() {
+      for (const client of sseClients) {
+        try {
+          client.write("data: reload\n\n");
+        } catch { /* client disconnected */ }
+      }
+    },
+
+    /** Push an SSE close event to all connected clients. */
+    closeClients() {
+      for (const client of sseClients) {
+        try {
+          client.write("data: close\n\n");
+        } catch { /* client disconnected */ }
+      }
+    },
+
+    /** Stop the server. */
+    stop() {
+      return new Promise((resolve) => {
+        if (!server) {
+          resolve();
+          return;
+        }
+        // Close all SSE connections
+        for (const client of sseClients) {
+          try { client.end(); } catch { /* ok */ }
+        }
+        sseClients = [];
+        server.close(() => {
+          server = null;
+          port = null;
+          resolve();
+        });
+      });
+    },
+
+    /** Get the current port (null if not running). */
+    getPort() { return port; },
+
+    /** Check if server is running. */
+    isRunning() { return server !== null; },
+  };
+}

--- a/.github/extensions/canvas/package.json
+++ b/.github/extensions/canvas/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "copilot-canvas-extension",
+  "private": true,
+  "type": "module"
+}

--- a/.github/extensions/canvas/tools/canvas-tools.mjs
+++ b/.github/extensions/canvas/tools/canvas-tools.mjs
@@ -1,0 +1,236 @@
+// Canvas tools — canvas_show, canvas_update, canvas_close
+
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { exec } from "node:child_process";
+
+const isWindows = process.platform === "win32";
+
+function openBrowser(url) {
+  const cmd = isWindows
+    ? `start msedge "${url}"`
+    : process.platform === "darwin"
+      ? `open -a "Microsoft Edge" "${url}"`
+      : `xdg-open "${url}"`;
+  exec(cmd, { shell: true }, () => {});
+}
+
+function writeContent(contentDir, filename, html) {
+  if (!existsSync(contentDir)) {
+    mkdirSync(contentDir, { recursive: true });
+  }
+  writeFileSync(join(contentDir, filename), html, "utf-8");
+}
+
+export function createCanvasTools(contentDir, server, onAction) {
+  // Track open canvases: name → { filename, url }
+  const openCanvases = new Map();
+
+  return [
+    {
+      name: "canvas_show",
+      description:
+        "Display HTML content in the user's browser. Creates a local canvas page and opens it in Edge. " +
+        "The HTML can be a full page or a fragment — a bridge script is auto-injected for live reload. " +
+        "Use this for dashboards, reports, visualizations, forms, or any rich visual output.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Canvas name (used as identifier). Kebab-case, e.g. 'daily-report', 'pr-dashboard'",
+          },
+          html: {
+            type: "string",
+            description: "Full HTML content to display. Can be a complete page or fragment. Not required if 'file' is provided.",
+          },
+          file: {
+            type: "string",
+            description: "Absolute path to an existing HTML file to serve. The file is copied into the canvas content directory. Use instead of 'html' to serve a pre-built file.",
+          },
+          title: {
+            type: "string",
+            description: "Optional page title. Used if html doesn't include a <title> tag.",
+          },
+          open_browser: {
+            type: "boolean",
+            description: "Whether to open the browser. Defaults to true. Set false to update content without opening a new tab.",
+          },
+        },
+        required: ["name"],
+      },
+      handler: async (args) => {
+        if (!args.html && !args.file) {
+          return "Error: either 'html' or 'file' must be provided.";
+        }
+
+        const filename = `${args.name}.html`;
+
+        if (args.file) {
+          // Serve an existing file — copy it into the content directory
+          if (!existsSync(args.file)) {
+            return `Error: file not found: ${args.file}`;
+          }
+          const source = readFileSync(args.file, "utf-8");
+          writeContent(contentDir, filename, source);
+        } else {
+          let html = args.html;
+
+          // Wrap fragment in a full page if needed
+          if (!html.toLowerCase().includes("<!doctype") && !html.toLowerCase().includes("<html")) {
+            const title = args.title || args.name;
+            html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+</head>
+<body>
+${html}
+</body>
+</html>`;
+          } else if (args.title && !html.toLowerCase().includes("<title>")) {
+            html = html.replace("</head>", `  <title>${args.title}</title>\n</head>`);
+          }
+
+          writeContent(contentDir, filename, html);
+        }
+
+        // Start server if not running
+        let port = server.getPort();
+        if (!port) {
+          port = await server.start();
+        }
+
+        const url = `http://127.0.0.1:${port}/${filename}`;
+        openCanvases.set(args.name, { filename, url });
+
+        const shouldOpen = args.open_browser !== false;
+        if (shouldOpen) {
+          openBrowser(url);
+        }
+
+        return `Canvas **${args.name}** is live at ${url}${shouldOpen ? " (opened in Edge)" : ""}`;
+      },
+    },
+
+    {
+      name: "canvas_update",
+      description:
+        "Update the content of an existing canvas. The browser auto-reloads via SSE — no need to reopen. " +
+        "Use this to refresh dashboards, update reports, or push new content to an already-open canvas.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Canvas name to update (must have been created with canvas_show)",
+          },
+          html: {
+            type: "string",
+            description: "New HTML content to display",
+          },
+          title: {
+            type: "string",
+            description: "Optional updated page title",
+          },
+        },
+        required: ["name", "html"],
+      },
+      handler: async (args) => {
+        const existing = openCanvases.get(args.name);
+        if (!existing) {
+          return `Error: canvas '${args.name}' not found. Use canvas_show to create it first.`;
+        }
+
+        let html = args.html;
+        if (!html.toLowerCase().includes("<!doctype") && !html.toLowerCase().includes("<html")) {
+          const title = args.title || args.name;
+          html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title}</title>
+</head>
+<body>
+${html}
+</body>
+</html>`;
+        }
+
+        writeContent(contentDir, existing.filename, html);
+        server.reload();
+
+        return `Canvas **${args.name}** updated. Browser will auto-reload.`;
+      },
+    },
+
+    {
+      name: "canvas_close",
+      description:
+        "Close a canvas and optionally stop the canvas server. " +
+        "Removes the canvas content. If no canvases remain, stops the server.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Canvas name to close. Use 'all' to close all canvases and stop the server.",
+          },
+        },
+        required: ["name"],
+      },
+      handler: async (args) => {
+        if (args.name === "all") {
+          const count = openCanvases.size;
+          server.closeClients();
+          await new Promise((r) => setTimeout(r, 200));
+          openCanvases.clear();
+          await server.stop();
+          return `Closed ${count} canvas(es) and stopped the server.`;
+        }
+
+        const existing = openCanvases.get(args.name);
+        if (!existing) {
+          return `Error: canvas '${args.name}' not found.`;
+        }
+
+        server.closeClients();
+        await new Promise((r) => setTimeout(r, 200));
+        openCanvases.delete(args.name);
+
+        // Stop server if no canvases remain
+        if (openCanvases.size === 0) {
+          await server.stop();
+          return `Canvas **${args.name}** closed. Server stopped (no remaining canvases).`;
+        }
+
+        return `Canvas **${args.name}** closed. ${openCanvases.size} canvas(es) still active.`;
+      },
+    },
+
+    {
+      name: "canvas_list",
+      description: "List all open canvases with their URLs.",
+      parameters: { type: "object", properties: {} },
+      handler: async () => {
+        if (openCanvases.size === 0) {
+          return "No canvases are open.";
+        }
+
+        const lines = [];
+        for (const [name, info] of openCanvases) {
+          lines.push(`• **${name}** — ${info.url}`);
+        }
+
+        const status = server.isRunning()
+          ? `Server running on port ${server.getPort()}`
+          : "Server not running";
+
+        return `${lines.join("\n")}\n\n${status}`;
+      },
+    },
+  ];
+}

--- a/.github/extensions/cron/README.md
+++ b/.github/extensions/cron/README.md
@@ -1,0 +1,167 @@
+# Cron Extension
+
+A Copilot CLI extension that adds scheduled job execution. Create jobs that run on a cron schedule, at fixed intervals, or fire once at a specific time. Jobs can execute shell commands or send prompts to the AI.
+
+## Setup
+
+After cloning or installing this extension, install npm dependencies:
+
+```bash
+cd .github/extensions/cron && npm install --no-fund --no-audit
+```
+
+> **Note:** The Copilot CLI does not auto-install npm dependencies for extensions. If the extension fails to load, this is almost always the fix.
+
+## Quick Example
+
+> "Schedule a job that checks my open PRs every morning at 9am and writes a summary to my inbox"
+
+That's it. The agent creates a **prompt job** ...  a scheduled AI session that runs autonomously:
+
+```
+cron_create:
+  name: morning-pr-review
+  scheduleType: cron
+  cronExpression: "0 9 * * 1-5"
+  timezone: "America/New_York"
+  payloadType: prompt
+  prompt: "Check my open GitHub PRs. For each one, note the age, review status, and any failing checks. Write a summary to inbox/pr-status.md."
+```
+
+Every weekday at 9am, the cron engine wakes up, spawns a Copilot session with your mind's identity, and runs that prompt. The AI does the work ...  you read the results.
+
+Prompt jobs aren't just reminders. They're **scheduled agents** ...  they can read files, call APIs, write output, and use any tool available to a normal Copilot session.
+
+## How It Works
+
+The extension registers tools with the Copilot CLI session. A background **engine** process ticks every 2 seconds, evaluates which jobs are due, and dispatches them. Jobs and run history are stored as JSON files in `data/`.
+
+The engine auto-starts when a Copilot session begins and runs independently as a detached process.
+
+## Tools
+
+### Job Management
+
+| Tool | Description |
+|------|-------------|
+| `cron_create` | Create a new scheduled job |
+| `cron_list` | List all jobs with status |
+| `cron_get` | Get job details and recent run history |
+| `cron_update` | Update a job's schedule, payload, or timeout |
+| `cron_delete` | Delete a job and its history |
+
+### Lifecycle
+
+| Tool | Description |
+|------|-------------|
+| `cron_pause` | Disable a job (keeps definition, stops execution) |
+| `cron_resume` | Re-enable a paused job |
+
+### Engine Control
+
+| Tool | Description |
+|------|-------------|
+| `cron_engine_start` | Start the background engine |
+| `cron_engine_stop` | Stop the engine gracefully |
+| `cron_engine_status` | Check if engine is running and job count |
+
+## Schedule Types
+
+**Cron** ...  Standard 5 or 6 field cron expressions with optional timezone.
+```
+Schedule every weekday at 9am Eastern:
+  scheduleType: cron
+  cronExpression: "0 9 * * 1-5"
+  timezone: "America/New_York"
+```
+
+**Interval** ...  Fixed millisecond interval between runs.
+```
+Run every 30 seconds:
+  scheduleType: interval
+  intervalMs: 30000
+```
+
+**One-shot** ...  Fire once at a specific UTC time, then disable.
+```
+Fire in 10 minutes:
+  scheduleType: oneShot
+  fireAtUtc: "2026-03-11T12:00:00.000Z"
+```
+
+## Payload Types
+
+**Command** ...  Run a shell command. Uses `shell: true` so built-ins and quoted arguments work.
+```
+payloadType: command
+command: echo
+arguments: "hello world"
+workingDirectory: C:\src\myproject
+timeoutSeconds: 300
+```
+
+**Prompt** ...  Send a prompt to the Copilot AI. Spawns a separate CopilotClient session.
+```
+payloadType: prompt
+prompt: "Summarize my open PRs"
+model: "claude-sonnet-4"
+sessionId: null
+timeoutSeconds: 120
+```
+
+Prompt jobs inherit the mind's identity (from `SOUL.md`) as a system message when available.
+
+`sessionId` (string, optional) — Custom session ID for prompt payloads. If provided, the Copilot session is created with this ID, enabling external tracking and correlation (e.g., by the Responses extension for background jobs).
+
+## Examples
+
+```
+"Create a job that says good morning every day at 8am"
+"Schedule a reminder to check PRs every hour"
+"Run my build script in 5 minutes"
+"Pause the morning-greeting job"
+"What jobs are running?"
+"Stop the cron engine"
+```
+
+## File Structure
+
+```
+.github/extensions/cron/
+├── extension.mjs          # Entry point ...  registers tools and hooks
+├── engine/
+│   └── main.mjs           # Detached engine process (tick loop)
+├── tools/
+│   ├── crud.mjs            # create, list, get, update, delete
+│   ├── lifecycle.mjs       # pause, resume
+│   └── engine-control.mjs  # start, stop, status
+├── lib/
+│   ├── scheduler.mjs       # Schedule evaluation and next-run calculation
+│   ├── executor.mjs        # Command execution (child_process)
+│   ├── prompt-executor.mjs # Prompt execution (Copilot SDK)
+│   ├── store.mjs           # Job persistence (JSON files)
+│   ├── history.mjs         # Run history tracking
+│   ├── lifecycle.mjs       # State transitions and backoff
+│   ├── identity.mjs        # Mind identity for prompt jobs
+│   ├── engine-autostart.mjs# Auto-start engine on session begin
+│   ├── paths.mjs           # Shared path helpers
+│   ├── stagger.mjs         # Startup stagger for interval jobs
+│   └── errors.mjs          # Error formatting
+├── data/
+│   ├── jobs/               # Job definitions (*.json)
+│   ├── history/            # Run history (*.json)
+│   ├── engine.lock         # Engine PID lockfile
+│   └── engine.log          # Engine log output
+└── package.json            # Dependencies (croner)
+```
+
+## Backoff
+
+Failed jobs use exponential backoff: 1min → 2min → 4min → 8min → 16min (max). The backoff resets on a successful run or when the job is resumed.
+
+## Limits
+
+- Max 3 concurrent job executions
+- Engine tick interval: 2 seconds
+- Command timeout default: 300 seconds
+- Prompt timeout default: 120 seconds

--- a/.github/extensions/cron/engine/main.mjs
+++ b/.github/extensions/cron/engine/main.mjs
@@ -1,0 +1,248 @@
+// Cron Engine — standalone detached process.
+// Tick loop reads jobs, evaluates schedules, dispatches due jobs.
+// Accepts --agent <name> to scope to a specific agent namespace.
+
+import { readFileSync, writeFileSync, unlinkSync, readdirSync, mkdirSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { listJobs, readJob, writeJob } from "../lib/store.mjs";
+import { isDue } from "../lib/scheduler.mjs";
+import { applyResult } from "../lib/lifecycle.mjs";
+import { executeCommand } from "../lib/executor.mjs";
+import { executePrompt } from "../lib/prompt-executor.mjs";
+import { appendHistory, createRunRecord } from "../lib/history.mjs";
+import { getCachedIdentity, clearIdentityCache } from "../lib/identity.mjs";
+import { getLockfilePath, getEngineLogPath, getAgentName, getDataDir } from "../lib/paths.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const extDir = resolve(__dirname, "..");
+
+// Parse --agent from CLI args, fall back to env var, then "default"
+function resolveAgentName() {
+  const idx = process.argv.indexOf("--agent");
+  if (idx !== -1 && process.argv[idx + 1]) {
+    const raw = process.argv[idx + 1].trim();
+    const sanitized = raw.replace(/[^a-zA-Z0-9_-]/g, "");
+    if (sanitized.length > 0) return sanitized;
+  }
+  return getAgentName();
+}
+
+const agentName = resolveAgentName();
+
+const TICK_INTERVAL_MS = 2000;
+const MAX_CONCURRENT = 3;
+
+const activeJobIds = new Set();
+let concurrentCount = 0;
+let shuttingDown = false;
+let tickTimer = null;
+let lastTickTime = Date.now();
+
+// --- Lockfile management ---
+
+function acquireLock() {
+  const lockPath = getLockfilePath(extDir, agentName);
+  // Ensure data directory exists
+  mkdirSync(getDataDir(extDir, agentName), { recursive: true });
+  // Check for stale lock
+  try {
+    const existingPid = parseInt(readFileSync(lockPath, "utf-8").trim(), 10);
+    if (existingPid && isProcessAlive(existingPid)) {
+      log(`Engine already running (PID ${existingPid}). Exiting.`);
+      process.exit(1);
+    }
+    // Stale lock — clean up
+    unlinkSync(lockPath);
+  } catch {
+    // No lockfile — proceed
+  }
+
+  writeFileSync(lockPath, String(process.pid), "utf-8");
+  log(`Engine started (PID ${process.pid}, agent: ${agentName}, Node ${process.version})`);
+}
+
+function releaseLock() {
+  try {
+    unlinkSync(getLockfilePath(extDir, agentName));
+  } catch { /* best effort */ }
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// --- Logging ---
+
+function log(message) {
+  const ts = new Date().toISOString();
+  const line = `[${ts}] ${message}`;
+  process.stderr.write(line + "\n");
+
+  // Also append to engine.log
+  try {
+    const logPath = getEngineLogPath(extDir, agentName);
+    mkdirSync(dirname(logPath), { recursive: true });
+    writeFileSync(logPath, line + "\n", { flag: "a" });
+  } catch { /* best effort */ }
+}
+
+// --- Tick loop ---
+
+async function tick() {
+  lastTickTime = Date.now();
+  if (shuttingDown) return;
+
+  try {
+    const jobs = listJobs(extDir, agentName);
+    const dueJobs = jobs
+      .filter((j) => isDue(j) && !activeJobIds.has(j.id))
+      .sort((a, b) => {
+        // Deterministic ordering: nextRunAtUtc then id
+        const ta = new Date(a.nextRunAtUtc).getTime();
+        const tb = new Date(b.nextRunAtUtc).getTime();
+        if (ta !== tb) return ta - tb;
+        return a.id.localeCompare(b.id);
+      });
+
+    for (const job of dueJobs) {
+      if (concurrentCount >= MAX_CONCURRENT) break;
+      if (activeJobIds.has(job.id)) continue;
+
+      // Non-blocking dispatch — .catch() prevents unhandled rejections
+      dispatch(job).catch((err) => {
+        log(`Unhandled dispatch error for ${job.id}: ${err.stack || err.message}`);
+      });
+    }
+  } catch (err) {
+    log(`Tick error: ${err.message}`);
+  }
+}
+
+async function dispatch(job) {
+  activeJobIds.add(job.id);
+  concurrentCount++;
+
+  const record = createRunRecord(job.id);
+  log(`Dispatching ${job.id} (${job.payload.type})`);
+
+  try {
+    let result;
+    if (job.payload.type === "command") {
+      result = await executeCommand(job.payload);
+    } else if (job.payload.type === "prompt") {
+      result = await executePrompt(extDir, job.payload);
+    } else {
+      result = { success: false, output: "", durationMs: 0, error: `Unknown payload type: ${job.payload.type}` };
+    }
+
+    // Complete the run record
+    record.completedAtUtc = new Date().toISOString();
+    record.outcome = result.success ? "success" : "failure";
+    record.errorMessage = result.error || null;
+    record.durationMs = result.durationMs;
+    record.output = result.output || null;
+
+    // Persist history
+    appendHistory(extDir, agentName, job.id, record);
+
+    // Apply lifecycle state transition
+    // Re-read job in case it was modified during execution
+    const currentJob = readJob(extDir, agentName, job.id);
+    if (currentJob) {
+      applyResult(currentJob, result);
+      writeJob(extDir, agentName, currentJob);
+    }
+
+    const emoji = result.success ? "✅" : "❌";
+    log(`${emoji} ${job.id}: ${record.outcome} (${record.durationMs}ms)${record.errorMessage ? " — " + record.errorMessage : ""}`);
+  } catch (err) {
+    log(`Dispatch error for ${job.id}: ${err.message}`);
+
+    record.completedAtUtc = new Date().toISOString();
+    record.outcome = "failure";
+    record.errorMessage = err.message;
+    record.durationMs = Date.now() - new Date(record.startedAtUtc).getTime();
+    appendHistory(extDir, agentName, job.id, record);
+  } finally {
+    activeJobIds.delete(job.id);
+    concurrentCount--;
+  }
+}
+
+// --- Shutdown ---
+
+async function shutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log(`Received ${signal}. Draining ${activeJobIds.size} active job(s)...`);
+
+  if (tickTimer) clearInterval(tickTimer);
+
+  // Wait for in-flight jobs (max 60s)
+  const deadline = Date.now() + 60_000;
+  while (activeJobIds.size > 0 && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  if (activeJobIds.size > 0) {
+    log(`Force exit with ${activeJobIds.size} job(s) still running.`);
+  }
+
+  releaseLock();
+  log("Engine stopped.");
+  process.exit(0);
+}
+
+// --- Global error handlers ---
+
+process.on("uncaughtException", (err, origin) => {
+  log(`UNCAUGHT EXCEPTION (${origin}): ${err.stack || err.message}`);
+  // Don't exit — the engine should keep running through transient errors.
+  // If the error is truly fatal, Node.js will exit anyway.
+});
+
+process.on("unhandledRejection", (reason) => {
+  const msg = reason instanceof Error ? reason.stack || reason.message : String(reason);
+  log(`UNHANDLED REJECTION: ${msg}`);
+  // Don't exit — log and continue. The dispatch try-catch should prevent
+  // most rejections, but this catches edge cases.
+});
+
+// --- Main ---
+
+// Pre-cache identity at startup
+getCachedIdentity(extDir);
+
+acquireLock();
+tickTimer = setInterval(tick, TICK_INTERVAL_MS);
+tick(); // First tick immediately
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
+// --- Tick watchdog ---
+// Detects if the tick loop has stalled and resets it.
+
+const WATCHDOG_INTERVAL_MS = 30_000;
+const WATCHDOG_MAX_STALL_MS = 60_000;
+
+setInterval(() => {
+  if (shuttingDown) return;
+  const stall = Date.now() - lastTickTime;
+  if (stall > WATCHDOG_MAX_STALL_MS) {
+    log(`WATCHDOG: Tick loop stalled for ${Math.round(stall / 1000)}s. Resetting.`);
+    if (tickTimer) clearInterval(tickTimer);
+    tickTimer = setInterval(tick, TICK_INTERVAL_MS);
+    tick();
+  }
+}, WATCHDOG_INTERVAL_MS);
+
+// Keep alive
+process.stdin.resume();

--- a/.github/extensions/cron/extension.mjs
+++ b/.github/extensions/cron/extension.mjs
@@ -1,0 +1,36 @@
+// Cron Extension — Entry Point
+// Registers cron tools and hooks with the Copilot CLI session.
+
+import { approveAll } from "@github/copilot-sdk";
+import { joinSession } from "@github/copilot-sdk/extension";
+
+import { createCrudTools } from "./tools/crud.mjs";
+import { createLifecycleTools } from "./tools/lifecycle.mjs";
+import { createEngineControlTools } from "./tools/engine-control.mjs";
+import { ensureEngine } from "./lib/engine-autostart.mjs";
+import { getExtensionDir, getAgentName } from "./lib/paths.mjs";
+import { migrateLegacyData } from "./lib/migration.mjs";
+
+const extDir = getExtensionDir();
+
+// Mutable agent state — tools can switch the agent namespace at runtime
+// (e.g., cron_engine_start --agent fox) since env vars can't be set
+// after extension processes spawn.
+const state = {
+  agentName: getAgentName(),
+};
+
+const session = await joinSession({
+  onPermissionRequest: approveAll,
+  hooks: {
+    onSessionStart: async () => {
+      migrateLegacyData(extDir, state.agentName);
+      await ensureEngine(extDir, state.agentName);
+    },
+  },
+  tools: [
+    ...createCrudTools(extDir, state),
+    ...createLifecycleTools(extDir, state),
+    ...createEngineControlTools(extDir, state),
+  ],
+});

--- a/.github/extensions/cron/lib/engine-autostart.mjs
+++ b/.github/extensions/cron/lib/engine-autostart.mjs
@@ -1,0 +1,55 @@
+// Engine autostart — checks if jobs exist and engine is running; starts if needed.
+
+import { readdirSync, readFileSync, unlinkSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { join } from "node:path";
+import { getJobsDir, getLockfilePath } from "./paths.mjs";
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Ensure the engine is running if there are jobs.
+ * Called on every session start via the onSessionStart hook.
+ */
+export async function ensureEngine(extDir, agentName) {
+  // Check if any jobs exist
+  let hasJobs = false;
+  try {
+    const jobsDir = getJobsDir(extDir, agentName);
+    const files = readdirSync(jobsDir).filter((f) => f.endsWith(".json"));
+    hasJobs = files.length > 0;
+  } catch {
+    // data/{agent}/jobs/ doesn't exist yet — no jobs
+  }
+
+  if (!hasJobs) return;
+
+  // Check if engine is already running
+  const lockPath = getLockfilePath(extDir, agentName);
+  try {
+    const raw = readFileSync(lockPath, "utf-8").trim();
+    const pid = parseInt(raw, 10);
+    if (pid && isProcessAlive(pid)) return; // engine is alive, nothing to do
+    // Stale lockfile — clean up
+    try { unlinkSync(lockPath); } catch { /* ok */ }
+  } catch {
+    // No lockfile — engine not running
+  }
+
+  // Start engine with agent namespace
+  const enginePath = join(extDir, "engine", "main.mjs");
+  const child = spawn("node", [enginePath, "--agent", agentName], {
+    detached: true,
+    stdio: "ignore",
+    windowsHide: true,
+    cwd: extDir,
+  });
+  child.unref();
+}

--- a/.github/extensions/cron/lib/errors.mjs
+++ b/.github/extensions/cron/lib/errors.mjs
@@ -1,0 +1,49 @@
+// Error classification — transient vs permanent.
+// Determines whether a failed job should retry or disable.
+
+/** Transient error patterns — these are retryable */
+const TRANSIENT_PATTERNS = [
+  /timeout/i,
+  /timed?\s*out/i,
+  /ETIMEDOUT/,
+  /ECONNRESET/,
+  /ECONNREFUSED/,
+  /ENOTFOUND/,
+  /ENETUNREACH/,
+  /EPIPE/,
+  /EAI_AGAIN/,
+  /network/i,
+  /socket hang up/i,
+  /rate limit/i,
+  /429/,
+  /503/,
+  /502/,
+  /504/,
+];
+
+/**
+ * Classify an error as transient or permanent.
+ * @param {Error|string} error
+ * @returns {"transient"|"permanent"}
+ */
+export function classifyError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = error?.code || "";
+
+  for (const pattern of TRANSIENT_PATTERNS) {
+    if (pattern.test(message) || pattern.test(code)) {
+      return "transient";
+    }
+  }
+
+  return "permanent";
+}
+
+/**
+ * Check if an error is transient (retryable).
+ * @param {Error|string} error
+ * @returns {boolean}
+ */
+export function isTransient(error) {
+  return classifyError(error) === "transient";
+}

--- a/.github/extensions/cron/lib/executor.mjs
+++ b/.github/extensions/cron/lib/executor.mjs
@@ -1,0 +1,103 @@
+// Command executor — spawn a command with timeout, combined output, process tree kill.
+
+import { spawn } from "node:child_process";
+
+/**
+ * Execute a command payload.
+ * @param {object} payload - { command, arguments, workingDirectory, timeoutSeconds }
+ * @returns {Promise<{ success: boolean, output: string, durationMs: number, error?: string }>}
+ */
+export function executeCommand(payload) {
+  return new Promise((resolve) => {
+    const startTime = Date.now();
+    const timeoutMs = (payload.timeoutSeconds || 300) * 1000;
+
+    const fullCommand = payload.arguments
+      ? `${payload.command} ${payload.arguments}`
+      : payload.command;
+    const options = {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      shell: true,
+      cwd: payload.workingDirectory || undefined,
+    };
+
+    let child;
+    try {
+      child = spawn(fullCommand, [], options);
+    } catch (err) {
+      resolve({
+        success: false,
+        output: "",
+        durationMs: Date.now() - startTime,
+        error: `Failed to spawn: ${err.message}`,
+      });
+      return;
+    }
+
+    let output = "";
+    let killed = false;
+
+    child.stdout.on("data", (chunk) => { output += chunk.toString(); });
+    child.stderr.on("data", (chunk) => { output += chunk.toString(); });
+
+    const timer = setTimeout(() => {
+      killed = true;
+      killProcessTree(child.pid);
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({
+        success: false,
+        output,
+        durationMs: Date.now() - startTime,
+        error: err.message,
+      });
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      const durationMs = Date.now() - startTime;
+
+      if (killed) {
+        resolve({
+          success: false,
+          output,
+          durationMs,
+          error: `Timed out after ${payload.timeoutSeconds}s`,
+        });
+      } else {
+        resolve({
+          success: code === 0,
+          output,
+          durationMs,
+          error: code !== 0 ? `Exit code ${code}` : undefined,
+        });
+      }
+    });
+  });
+}
+
+/**
+ * Kill a process tree.
+ * On Windows: taskkill /T /F /PID
+ * On Unix: kill the process group
+ */
+function killProcessTree(pid) {
+  if (!pid) return;
+  try {
+    if (process.platform === "win32") {
+      spawn("taskkill", ["/T", "/F", "/PID", String(pid)], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+    } else {
+      // Kill the process group
+      try { process.kill(-pid, "SIGKILL"); } catch { /* ignore */ }
+      try { process.kill(pid, "SIGKILL"); } catch { /* ignore */ }
+    }
+  } catch {
+    // Best effort
+  }
+}

--- a/.github/extensions/cron/lib/history.mjs
+++ b/.github/extensions/cron/lib/history.mjs
@@ -1,0 +1,77 @@
+// Run history — per-job append with auto-prune.
+
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { getHistoryDir } from "./paths.mjs";
+
+const MAX_RECORDS = 500;
+const MAX_BYTES = 1_048_576; // 1 MB
+
+/** Ensure the history directory exists */
+function ensureHistoryDir(extDir, agentName) {
+  mkdirSync(getHistoryDir(extDir, agentName), { recursive: true });
+}
+
+/** Read history for a job. Returns array of run records (newest first). */
+export function readHistory(extDir, agentName, jobId) {
+  try {
+    const raw = readFileSync(join(getHistoryDir(extDir, agentName), `${jobId}.json`), "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+/** Append a run record and auto-prune. */
+export function appendHistory(extDir, agentName, jobId, record) {
+  ensureHistoryDir(extDir, agentName);
+  const filePath = join(getHistoryDir(extDir, agentName), `${jobId}.json`);
+
+  let history = readHistory(extDir, agentName, jobId);
+  history.push(record);
+
+  // Prune by count
+  if (history.length > MAX_RECORDS) {
+    history = history.slice(history.length - MAX_RECORDS);
+  }
+
+  // Prune by size
+  let serialized = JSON.stringify(history, null, 2);
+  while (Buffer.byteLength(serialized, "utf-8") > MAX_BYTES && history.length > 1) {
+    history.shift();
+    serialized = JSON.stringify(history, null, 2);
+  }
+
+  writeFileSync(filePath, serialized, "utf-8");
+}
+
+/** Delete history for a job. */
+export function deleteHistory(extDir, agentName, jobId) {
+  try {
+    unlinkSync(join(getHistoryDir(extDir, agentName), `${jobId}.json`));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Create a new run record template. */
+export function createRunRecord(jobId) {
+  return {
+    runId: randomUUID(),
+    jobId,
+    startedAtUtc: new Date().toISOString(),
+    completedAtUtc: null,
+    outcome: null, // "success" | "failure"
+    errorMessage: null,
+    durationMs: null,
+    output: null,
+  };
+}
+
+/** Get recent history (last N records). */
+export function getRecentHistory(extDir, agentName, jobId, count = 10) {
+  const history = readHistory(extDir, agentName, jobId);
+  return history.slice(-count);
+}

--- a/.github/extensions/cron/lib/identity.mjs
+++ b/.github/extensions/cron/lib/identity.mjs
@@ -1,0 +1,72 @@
+// Identity loader — assembles SOUL.md + agent files into a system message.
+// Caches result at engine startup since identity doesn't change between runs.
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { getMindRoot } from "./paths.mjs";
+
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+
+/** Strip YAML frontmatter from markdown content */
+function stripFrontmatter(content) {
+  return content.replace(FRONTMATTER_RE, "").trim();
+}
+
+/** Read a file, return null on error */
+function safeRead(filePath) {
+  try {
+    return readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load the mind's identity: SOUL.md + all agent files.
+ * Returns a single string suitable for SystemMessage injection.
+ */
+export function loadIdentity(extDir) {
+  const mindRoot = getMindRoot(extDir);
+  const parts = [];
+
+  // 1. Read SOUL.md
+  const soul = safeRead(join(mindRoot, "SOUL.md"));
+  if (soul) {
+    parts.push(soul);
+  }
+
+  // 2. Glob .github/agents/*.agent.md, sorted alphabetically
+  const agentsDir = join(mindRoot, ".github", "agents");
+  try {
+    const agentFiles = readdirSync(agentsDir)
+      .filter((f) => f.endsWith(".agent.md"))
+      .sort();
+
+    for (const file of agentFiles) {
+      const content = safeRead(join(agentsDir, file));
+      if (content) {
+        parts.push(stripFrontmatter(content));
+      }
+    }
+  } catch {
+    // agents directory may not exist yet
+  }
+
+  return parts.join("\n\n---\n\n");
+}
+
+// Cached identity for engine use
+let cachedIdentity = null;
+
+/** Get cached identity, loading on first call */
+export function getCachedIdentity(extDir) {
+  if (cachedIdentity === null) {
+    cachedIdentity = loadIdentity(extDir);
+  }
+  return cachedIdentity;
+}
+
+/** Clear cache (useful for testing) */
+export function clearIdentityCache() {
+  cachedIdentity = null;
+}

--- a/.github/extensions/cron/lib/lifecycle.mjs
+++ b/.github/extensions/cron/lib/lifecycle.mjs
@@ -1,0 +1,108 @@
+// Lifecycle state machine — handles job state transitions after execution.
+// Ports Gateway's CronJobLifecycle.ApplyResult() logic.
+
+import { calculateNextRun } from "./scheduler.mjs";
+import { classifyError } from "./errors.mjs";
+
+// Exponential backoff steps: 30s → 1m → 5m → 15m → 1h (capped)
+const BACKOFF_STEPS_MS = [
+  30_000,      // 30s
+  60_000,      // 1m
+  300_000,     // 5m
+  900_000,     // 15m
+  3_600_000,   // 1h
+];
+
+const MAX_CONSECUTIVE_FAILURES = 10;
+
+/**
+ * Apply a run result to a job, returning the updated job.
+ * Mutates the job object in place.
+ *
+ * @param {object} job - The job object
+ * @param {{ success: boolean, error?: string }} result - The execution result
+ * @returns {object} The mutated job
+ */
+export function applyResult(job, result) {
+  const now = new Date();
+  job.lastRunAtUtc = now.toISOString();
+
+  if (result.success) {
+    return applySuccess(job);
+  } else {
+    return applyFailure(job, result.error || "Unknown error");
+  }
+}
+
+/** Handle successful execution */
+function applySuccess(job) {
+  // Reset backoff on success
+  job.backoff = null;
+
+  // One-shot jobs disable after success
+  if (job.schedule.type === "oneShot") {
+    job.status = "disabled";
+    job.nextRunAtUtc = null;
+    return job;
+  }
+
+  // Calculate next run
+  job.nextRunAtUtc = calculateNextRun(job.schedule, job.lastRunAtUtc);
+  return job;
+}
+
+/** Handle failed execution */
+function applyFailure(job, errorMessage) {
+  const errorType = classifyError(errorMessage);
+
+  if (errorType === "permanent") {
+    // Permanent errors disable the job immediately
+    job.status = "disabled";
+    job.nextRunAtUtc = null;
+    job.backoff = {
+      consecutiveFailures: (job.backoff?.consecutiveFailures || 0) + 1,
+      nextRetryAtUtc: null,
+      lastErrorMessage: errorMessage,
+    };
+    return job;
+  }
+
+  // Transient errors use exponential backoff
+  const failures = (job.backoff?.consecutiveFailures || 0) + 1;
+
+  // Circuit breaker: disable after too many consecutive failures
+  if (failures >= MAX_CONSECUTIVE_FAILURES) {
+    job.status = "disabled";
+    job.nextRunAtUtc = null;
+    job.backoff = {
+      consecutiveFailures: failures,
+      nextRetryAtUtc: null,
+      lastErrorMessage: `Disabled after ${failures} consecutive failures. Last: ${errorMessage}`,
+    };
+    return job;
+  }
+
+  const stepIndex = Math.min(failures - 1, BACKOFF_STEPS_MS.length - 1);
+  const delayMs = BACKOFF_STEPS_MS[stepIndex];
+  const retryAt = new Date(Date.now() + delayMs);
+
+  job.backoff = {
+    consecutiveFailures: failures,
+    nextRetryAtUtc: retryAt.toISOString(),
+    lastErrorMessage: errorMessage,
+  };
+
+  // Keep nextRunAtUtc as-is — the isDue() check uses backoff.nextRetryAtUtc
+  return job;
+}
+
+/**
+ * Check if a job has been disabled due to permanent failure.
+ * @param {object} job
+ * @returns {boolean}
+ */
+export function isPermanentlyFailed(job) {
+  return job.status === "disabled" &&
+    job.backoff !== null &&
+    job.backoff.nextRetryAtUtc === null;
+}

--- a/.github/extensions/cron/lib/migration.mjs
+++ b/.github/extensions/cron/lib/migration.mjs
@@ -1,0 +1,72 @@
+// Migration — moves flat data/ layout to namespaced data/{agent}/ directories.
+// Idempotent — safe to call every session.
+
+import { existsSync, mkdirSync, readdirSync, renameSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Migrate legacy flat data/{jobs,history,engine.lock,engine.log} into the
+ * namespaced data/{agentName}/ directory. If the target already exists the
+ * old copy is simply removed.
+ *
+ * Layout before:  data/jobs/*.json, data/history/*.json, data/engine.lock, data/engine.log
+ * Layout after:   data/{agentName}/jobs/*.json, data/{agentName}/history/*.json, ...
+ */
+export function migrateLegacyData(extDir, agentName) {
+  const dataDir = join(extDir, "data");
+  const targetDir = join(dataDir, agentName);
+
+  // Migrate directories (jobs, history)
+  for (const dirName of ["jobs", "history"]) {
+    const oldDir = join(dataDir, dirName);
+    const newDir = join(targetDir, dirName);
+
+    if (!existsSync(oldDir)) continue;
+
+    // Check if old dir contains .json files (not just .gitkeep)
+    let jsonFiles;
+    try {
+      jsonFiles = readdirSync(oldDir).filter((f) => f.endsWith(".json"));
+    } catch {
+      continue;
+    }
+
+    if (jsonFiles.length === 0) continue;
+
+    mkdirSync(newDir, { recursive: true });
+
+    for (const file of jsonFiles) {
+      const oldPath = join(oldDir, file);
+      const newPath = join(newDir, file);
+
+      try {
+        if (existsSync(newPath)) {
+          unlinkSync(oldPath);
+        } else {
+          renameSync(oldPath, newPath);
+        }
+      } catch (err) {
+        if (err.code !== "ENOENT") throw err;
+      }
+    }
+  }
+
+  // Migrate flat files (engine.lock, engine.log)
+  for (const filename of ["engine.lock", "engine.log"]) {
+    const oldPath = join(dataDir, filename);
+    const newPath = join(targetDir, filename);
+
+    if (!existsSync(oldPath)) continue;
+
+    try {
+      mkdirSync(targetDir, { recursive: true });
+      if (existsSync(newPath)) {
+        unlinkSync(oldPath);
+      } else {
+        renameSync(oldPath, newPath);
+      }
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+  }
+}

--- a/.github/extensions/cron/lib/paths.mjs
+++ b/.github/extensions/cron/lib/paths.mjs
@@ -1,0 +1,52 @@
+// Shared path helpers for the cron extension.
+
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Extension root directory (.github/extensions/cron/) */
+export function getExtensionDir() {
+  return resolve(__dirname, "..");
+}
+
+/** Mind repository root (three levels up from extension dir) */
+export function getMindRoot(extDir) {
+  return resolve(extDir, "..", "..", "..");
+}
+
+/**
+ * Derive the agent name from COPILOT_AGENT env var.
+ * Only [a-zA-Z0-9_-] characters are kept (filesystem safety).
+ * Falls back to "default" if empty or entirely invalid.
+ */
+export function getAgentName() {
+  const raw = (process.env.COPILOT_AGENT || "").trim();
+  const sanitized = raw.replace(/[^a-zA-Z0-9_-]/g, "");
+  return sanitized.length > 0 ? sanitized : "default";
+}
+
+/** Data directory for an agent's runtime state */
+export function getDataDir(extDir, agentName) {
+  return join(extDir, "data", agentName);
+}
+
+/** Jobs directory for an agent */
+export function getJobsDir(extDir, agentName) {
+  return join(getDataDir(extDir, agentName), "jobs");
+}
+
+/** History directory for an agent */
+export function getHistoryDir(extDir, agentName) {
+  return join(getDataDir(extDir, agentName), "history");
+}
+
+/** Engine lockfile path for an agent */
+export function getLockfilePath(extDir, agentName) {
+  return join(getDataDir(extDir, agentName), "engine.lock");
+}
+
+/** Engine log path for an agent */
+export function getEngineLogPath(extDir, agentName) {
+  return join(getDataDir(extDir, agentName), "engine.log");
+}

--- a/.github/extensions/cron/lib/prompt-executor.mjs
+++ b/.github/extensions/cron/lib/prompt-executor.mjs
@@ -1,0 +1,181 @@
+// Prompt executor — spawns a CopilotClient with the mind's identity.
+// Resolves the SDK from ~/.copilot/pkg/universal/.
+// Loads code-exec tools so prompt jobs can access MCP data sources.
+
+import { readdirSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { getCachedIdentity } from "./identity.mjs";
+import { getMindRoot } from "./paths.mjs";
+
+/**
+ * Resolve the Copilot SDK from the well-known install location.
+ * @returns {Promise<{ CopilotClient: any }>}
+ */
+async function resolveSdk() {
+  const pkgRoot = join(homedir(), ".copilot", "pkg");
+
+  // Platform-specific directory first, then universal fallback
+  const platformDir = `${process.platform}-${process.arch}`;
+  const searchDirs = [join(pkgRoot, platformDir), join(pkgRoot, "universal")];
+
+  for (const sdkBase of searchDirs) {
+    let versions;
+    try {
+      versions = readdirSync(sdkBase)
+        .filter((d) => !d.startsWith("."))
+        .sort();
+    } catch {
+      continue; // directory doesn't exist, try next
+    }
+
+    if (versions.length === 0) continue;
+
+    const latest = versions[versions.length - 1];
+    const sdkPath = join(sdkBase, latest, "copilot-sdk", "index.js");
+
+    try {
+      return await import(`file://${sdkPath.replace(/\\/g, "/")}`);
+    } catch {
+      continue; // SDK not in this version dir, try next
+    }
+  }
+
+  throw new Error(
+    `Cannot find Copilot SDK in any of: ${searchDirs.join(", ")}`
+  );
+}
+
+/**
+ * Resolve the code-exec extension directory and load its tool factories.
+ * Returns the three tools (discover, call_tool, execute_script) ready for
+ * SessionConfig.tools, or an empty array if code-exec is not available.
+ *
+ * @param {string} cronExtDir - The cron extension directory
+ * @returns {Promise<Array<object>>} Tool definitions for createSession
+ */
+async function loadCodeExecTools(cronExtDir) {
+  const codeExecDir = resolve(cronExtDir, "..", "code-exec");
+
+  if (!existsSync(join(codeExecDir, "extension.mjs"))) {
+    return [];
+  }
+
+  try {
+    const { createDiscoverTool } = await import(
+      `file://${join(codeExecDir, "tools", "discover.mjs").replace(/\\/g, "/")}`
+    );
+    const { createCallToolTool } = await import(
+      `file://${join(codeExecDir, "tools", "call-tool.mjs").replace(/\\/g, "/")}`
+    );
+    const { createExecuteScriptTool } = await import(
+      `file://${join(codeExecDir, "tools", "execute-script.mjs").replace(/\\/g, "/")}`
+    );
+    const { loadConfig, getEnabledServers } = await import(
+      `file://${join(codeExecDir, "lib", "config.mjs").replace(/\\/g, "/")}`
+    );
+
+    // Pre-load server names for the discover tool description
+    let serverNames = [];
+    try {
+      const config = loadConfig(codeExecDir);
+      serverNames = getEnabledServers(config).map(([n]) => n);
+    } catch {
+      // Config not present — serverNames stays empty
+    }
+
+    return [
+      createDiscoverTool(codeExecDir, serverNames),
+      createCallToolTool(codeExecDir),
+      createExecuteScriptTool(codeExecDir),
+    ];
+  } catch (err) {
+    process.stderr.write(
+      `[prompt-executor] Failed to load code-exec tools: ${err.message}\n`
+    );
+    return [];
+  }
+}
+
+/**
+ * Execute a prompt payload using the Copilot SDK.
+ * @param {string} extDir - Extension directory
+ * @param {object} payload - { prompt, model?, preloadToolNames?, timeoutSeconds, sessionId? }
+ * @returns {Promise<{ success: boolean, output: string, durationMs: number, error?: string }>}
+ */
+export async function executePrompt(extDir, payload) {
+  const startTime = Date.now();
+  const timeoutMs = (payload.timeoutSeconds || 120) * 1000;
+  const mindRoot = getMindRoot(extDir);
+  const identity = getCachedIdentity(extDir);
+
+  let sdk;
+  try {
+    sdk = await resolveSdk();
+  } catch (err) {
+    return {
+      success: false,
+      output: "",
+      durationMs: Date.now() - startTime,
+      error: `SDK resolution failed: ${err.message}`,
+    };
+  }
+
+  // Load code-exec tools so the agent can access MCP data sources
+  const codeExecTools = await loadCodeExecTools(extDir);
+
+  let client;
+  try {
+    client = new sdk.CopilotClient({
+      cwd: mindRoot,
+      autoStart: true,
+    });
+
+    const sessionOpts = {
+      onPermissionRequest: sdk.approveAll,
+    };
+    if (payload.model) {
+      sessionOpts.model = payload.model;
+    }
+    if (payload.sessionId) {
+      sessionOpts.sessionId = payload.sessionId;
+    }
+    if (identity) {
+      sessionOpts.systemMessage = {
+        mode: "append",
+        content: identity,
+      };
+    }
+    if (codeExecTools.length > 0) {
+      sessionOpts.tools = codeExecTools;
+    }
+
+    const session = await client.createSession(sessionOpts);
+
+    const response = await session.sendAndWait(
+      { prompt: payload.prompt },
+      timeoutMs,
+    );
+
+    const output = response?.data?.content || response?.content || "";
+
+    return {
+      success: true,
+      output,
+      durationMs: Date.now() - startTime,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      output: "",
+      durationMs: Date.now() - startTime,
+      error: err.message,
+    };
+  } finally {
+    try {
+      if (client && typeof client.stop === "function") {
+        client.stop();
+      }
+    } catch { /* best effort */ }
+  }
+}

--- a/.github/extensions/cron/lib/scheduler.mjs
+++ b/.github/extensions/cron/lib/scheduler.mjs
@@ -1,0 +1,116 @@
+// Schedule evaluation — cron, interval, and one-shot.
+// Uses croner for cron expression parsing with timezone support.
+
+import { Cron } from "croner";
+
+/**
+ * Calculate the next run time for a schedule.
+ * @param {object} schedule - { type, expression?, timezone?, intervalMs?, fireAtUtc? }
+ * @param {Date|null} lastRunAt - When the job last ran (null if never)
+ * @returns {string|null} ISO 8601 UTC timestamp, or null if no future run
+ */
+export function calculateNextRun(schedule, lastRunAt = null) {
+  const now = new Date();
+
+  switch (schedule.type) {
+    case "cron": {
+      const opts = {};
+      if (schedule.timezone) {
+        opts.timezone = schedule.timezone;
+      }
+      const job = new Cron(schedule.expression, opts);
+      const next = job.nextRun(now);
+      return next ? next.toISOString() : null;
+    }
+
+    case "interval": {
+      if (lastRunAt) {
+        const last = new Date(lastRunAt);
+        const next = new Date(last.getTime() + schedule.intervalMs);
+        // If next is in the past, fire immediately (relative to now)
+        return next <= now ? now.toISOString() : next.toISOString();
+      }
+      // First run fires immediately
+      return now.toISOString();
+    }
+
+    case "oneShot": {
+      const fireAt = new Date(schedule.fireAtUtc);
+      return fireAt > now ? fireAt.toISOString() : null;
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Check if a job is due to run.
+ * @param {object} job - The job object
+ * @returns {boolean}
+ */
+export function isDue(job) {
+  if (job.status !== "enabled") return false;
+  if (!job.nextRunAtUtc) return false;
+
+  const now = new Date();
+  const nextRun = new Date(job.nextRunAtUtc);
+
+  if (nextRun > now) return false;
+
+  // Check backoff
+  if (job.backoff && job.backoff.nextRetryAtUtc) {
+    const retryAt = new Date(job.backoff.nextRetryAtUtc);
+    if (retryAt > now) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Validate a schedule object.
+ * @param {object} schedule
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateSchedule(schedule) {
+  if (!schedule || !schedule.type) {
+    return { valid: false, error: "Schedule must have a type" };
+  }
+
+  switch (schedule.type) {
+    case "cron": {
+      if (!schedule.expression) {
+        return { valid: false, error: "Cron schedule requires an expression" };
+      }
+      try {
+        const opts = {};
+        if (schedule.timezone) opts.timezone = schedule.timezone;
+        new Cron(schedule.expression, opts);
+        return { valid: true };
+      } catch (e) {
+        return { valid: false, error: `Invalid cron expression: ${e.message}` };
+      }
+    }
+
+    case "interval": {
+      if (!schedule.intervalMs || schedule.intervalMs < 1000) {
+        return { valid: false, error: "Interval must be at least 1000ms" };
+      }
+      return { valid: true };
+    }
+
+    case "oneShot": {
+      if (!schedule.fireAtUtc) {
+        return { valid: false, error: "One-shot schedule requires fireAtUtc" };
+      }
+      const d = new Date(schedule.fireAtUtc);
+      if (isNaN(d.getTime())) {
+        return { valid: false, error: "Invalid fireAtUtc date" };
+      }
+      return { valid: true };
+    }
+
+    default:
+      return { valid: false, error: `Unknown schedule type: ${schedule.type}` };
+  }
+}

--- a/.github/extensions/cron/lib/stagger.mjs
+++ b/.github/extensions/cron/lib/stagger.mjs
@@ -1,0 +1,35 @@
+// Stagger — deterministic offset per job ID to prevent thundering herd.
+// Uses SHA-256 hash of job ID to produce a stable offset within a window.
+
+import { createHash } from "node:crypto";
+
+const DEFAULT_WINDOW_MS = 30_000; // 30 second stagger window
+
+/**
+ * Calculate a deterministic stagger offset for a job ID.
+ * The same job ID always produces the same offset.
+ *
+ * @param {string} jobId - The job ID
+ * @param {number} windowMs - Maximum stagger window in milliseconds
+ * @returns {number} Offset in milliseconds (0 to windowMs)
+ */
+export function getStaggerOffset(jobId, windowMs = DEFAULT_WINDOW_MS) {
+  const hash = createHash("sha256").update(jobId).digest();
+  // Use first 4 bytes as uint32
+  const value = hash.readUInt32BE(0);
+  return Math.floor((value / 0xFFFFFFFF) * windowMs);
+}
+
+/**
+ * Apply stagger to a next-run timestamp.
+ * @param {string} nextRunAtUtc - ISO 8601 timestamp
+ * @param {string} jobId - The job ID for deterministic offset
+ * @param {number} windowMs - Stagger window
+ * @returns {string} Adjusted ISO 8601 timestamp
+ */
+export function applyStagger(nextRunAtUtc, jobId, windowMs = DEFAULT_WINDOW_MS) {
+  if (!nextRunAtUtc) return nextRunAtUtc;
+  const base = new Date(nextRunAtUtc);
+  const offset = getStaggerOffset(jobId, windowMs);
+  return new Date(base.getTime() + offset).toISOString();
+}

--- a/.github/extensions/cron/lib/store.mjs
+++ b/.github/extensions/cron/lib/store.mjs
@@ -1,0 +1,79 @@
+// Job store — one JSON file per job with atomic writes.
+
+import { readFileSync, writeFileSync, unlinkSync, readdirSync, mkdirSync, renameSync } from "node:fs";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getJobsDir } from "./paths.mjs";
+
+/**
+ * Atomic write: write to temp file, then rename.
+ * Rename is atomic on both NTFS and Linux.
+ */
+function atomicWrite(filePath, data) {
+  const tmp = filePath + "." + randomBytes(6).toString("hex") + ".tmp";
+  try {
+    writeFileSync(tmp, JSON.stringify(data, null, 2), "utf-8");
+    renameSync(tmp, filePath);
+  } finally {
+    try { unlinkSync(tmp); } catch { /* tmp already renamed or never written */ }
+  }
+}
+
+/** Convert a name to a kebab-case ID */
+export function nameToId(name) {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/** Ensure the jobs directory exists */
+function ensureJobsDir(extDir, agentName) {
+  mkdirSync(getJobsDir(extDir, agentName), { recursive: true });
+}
+
+/** Read a single job by ID. Returns null if not found. */
+export function readJob(extDir, agentName, jobId) {
+  try {
+    const raw = readFileSync(join(getJobsDir(extDir, agentName), `${jobId}.json`), "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** List all jobs. Returns an array of job objects. */
+export function listJobs(extDir, agentName) {
+  ensureJobsDir(extDir, agentName);
+  const dir = getJobsDir(extDir, agentName);
+  const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  return files.map((f) => {
+    try {
+      return JSON.parse(readFileSync(join(dir, f), "utf-8"));
+    } catch {
+      return null;
+    }
+  }).filter(Boolean);
+}
+
+/** Write a job (create or update). */
+export function writeJob(extDir, agentName, job) {
+  ensureJobsDir(extDir, agentName);
+  atomicWrite(join(getJobsDir(extDir, agentName), `${job.id}.json`), job);
+}
+
+/** Delete a job by ID. Returns true if deleted, false if not found. */
+export function deleteJob(extDir, agentName, jobId) {
+  try {
+    unlinkSync(join(getJobsDir(extDir, agentName), `${jobId}.json`));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Check if a job ID already exists. */
+export function jobExists(extDir, agentName, jobId) {
+  return readJob(extDir, agentName, jobId) !== null;
+}

--- a/.github/extensions/cron/package.json
+++ b/.github/extensions/cron/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "copilot-cron-extension",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "croner": "^9.0.0"
+  }
+}

--- a/.github/extensions/cron/tools/crud.mjs
+++ b/.github/extensions/cron/tools/crud.mjs
@@ -1,0 +1,284 @@
+// CRUD tools — cron_create, cron_list, cron_get, cron_update, cron_delete
+
+import { nameToId, readJob, listJobs, writeJob, deleteJob, jobExists } from "../lib/store.mjs";
+import { calculateNextRun, validateSchedule } from "../lib/scheduler.mjs";
+import { getRecentHistory, deleteHistory } from "../lib/history.mjs";
+
+function makeJob(name, id, schedule, payload) {
+  return {
+    id,
+    name,
+    status: "enabled",
+    maxConcurrency: 1,
+    createdAtUtc: new Date().toISOString(),
+    createdFrom: process.cwd(),
+    lastRunAtUtc: null,
+    nextRunAtUtc: calculateNextRun(schedule),
+    schedule,
+    payload,
+    backoff: null,
+  };
+}
+
+function formatJobSummary(job) {
+  const status = job.status === "enabled" ? "✅" : "⏸️";
+  const next = job.nextRunAtUtc ? new Date(job.nextRunAtUtc).toLocaleString() : "none";
+  const type = job.payload?.type || "unknown";
+  return `${status} **${job.name}** (${job.id}) — ${type} | next: ${next}`;
+}
+
+export function createCrudTools(extDir, state) {
+  return [
+    {
+      name: "cron_create",
+      description: "Create a new scheduled cron job. Supports command jobs (run a shell command) and prompt jobs (send a prompt to the AI).",
+      parameters: {
+        type: "object",
+        properties: {
+          name: { type: "string", description: "Human-readable job name (used to derive the job ID)" },
+          scheduleType: {
+            type: "string",
+            enum: ["cron", "interval", "oneShot"],
+            description: "Schedule type: 'cron' (cron expression), 'interval' (fixed ms), 'oneShot' (fire once)",
+          },
+          cronExpression: { type: "string", description: "Cron expression (5 or 6 field). Required when scheduleType is 'cron'." },
+          timezone: { type: "string", description: "IANA timezone for cron (e.g. 'America/Chicago'). Defaults to UTC." },
+          intervalMs: { type: "number", description: "Interval in milliseconds. Required when scheduleType is 'interval'." },
+          fireAtUtc: { type: "string", description: "ISO 8601 UTC timestamp. Required when scheduleType is 'oneShot'." },
+          payloadType: {
+            type: "string",
+            enum: ["command", "prompt"],
+            description: "What to execute: 'command' (shell) or 'prompt' (AI)",
+          },
+          command: { type: "string", description: "Executable name or path. Required for command payloads." },
+          arguments: { type: "string", description: "Command-line arguments. Optional for command payloads." },
+          workingDirectory: { type: "string", description: "Working directory for command. Defaults to user home." },
+          prompt: { type: "string", description: "The prompt to send to the LLM. Required for prompt payloads." },
+          model: { type: "string", description: "Model override for prompt payloads (e.g. 'claude-sonnet-4.5')." },
+          sessionId: { type: "string", description: "Custom session ID for prompt payloads. If provided, the Copilot session is created with this ID for tracking." },
+          timeoutSeconds: { type: "number", description: "Timeout in seconds. Default: 300 for commands, 120 for prompts." },
+        },
+        required: ["name", "scheduleType", "payloadType"],
+      },
+      handler: async (args) => {
+        const id = nameToId(args.name);
+        if (!id) return "Error: name produces an empty ID.";
+        if (jobExists(extDir, state.agentName, id)) return `Error: job '${id}' already exists. Use cron_update to modify it.`;
+
+        // Build schedule
+        const schedule = { type: args.scheduleType };
+        if (args.scheduleType === "cron") {
+          schedule.expression = args.cronExpression;
+          schedule.timezone = args.timezone || null;
+        } else if (args.scheduleType === "interval") {
+          schedule.intervalMs = args.intervalMs;
+        } else if (args.scheduleType === "oneShot") {
+          schedule.fireAtUtc = args.fireAtUtc;
+        }
+
+        const validation = validateSchedule(schedule);
+        if (!validation.valid) return `Error: ${validation.error}`;
+
+        // Build payload
+        const payload = { type: args.payloadType };
+        if (args.payloadType === "command") {
+          if (!args.command) return "Error: command is required for command payloads.";
+          payload.command = args.command;
+          payload.arguments = args.arguments || null;
+          payload.workingDirectory = args.workingDirectory || null;
+          payload.timeoutSeconds = args.timeoutSeconds || 300;
+        } else if (args.payloadType === "prompt") {
+          if (!args.prompt) return "Error: prompt is required for prompt payloads.";
+          payload.prompt = args.prompt;
+          payload.model = args.model || null;
+          payload.sessionId = args.sessionId || null;
+          payload.preloadToolNames = null;
+          payload.timeoutSeconds = args.timeoutSeconds || 120;
+        }
+
+        const job = makeJob(args.name, id, schedule, payload);
+        writeJob(extDir, state.agentName, job);
+
+        return `Created job **${job.name}** (${job.id}).\n` +
+          `Schedule: ${job.schedule.type}` +
+          (job.schedule.expression ? ` \`${job.schedule.expression}\`` : "") +
+          (job.schedule.intervalMs ? ` every ${job.schedule.intervalMs}ms` : "") +
+          `\nNext run: ${job.nextRunAtUtc || "none"}\n` +
+          `Payload: ${job.payload.type}` +
+          (job.payload.command ? ` — \`${job.payload.command} ${job.payload.arguments || ""}\`` : "") +
+          (job.payload.prompt ? ` — "${job.payload.prompt.slice(0, 80)}..."` : "");
+      },
+    },
+
+    {
+      name: "cron_list",
+      description: "List all cron jobs with status and next run time.",
+      parameters: {
+        type: "object",
+        properties: {
+          status: {
+            type: "string",
+            enum: ["enabled", "disabled"],
+            description: "Optional filter by job status.",
+          },
+        },
+      },
+      handler: async (args) => {
+        let jobs = listJobs(extDir, state.agentName);
+        if (args.status) {
+          jobs = jobs.filter((j) => j.status === args.status);
+        }
+        if (jobs.length === 0) return "No cron jobs found.";
+
+        // Sort by nextRunAtUtc
+        jobs.sort((a, b) => {
+          if (!a.nextRunAtUtc) return 1;
+          if (!b.nextRunAtUtc) return -1;
+          return new Date(a.nextRunAtUtc) - new Date(b.nextRunAtUtc);
+        });
+
+        const lines = jobs.map(formatJobSummary);
+        return `**${jobs.length} job(s):**\n\n` + lines.join("\n");
+      },
+    },
+
+    {
+      name: "cron_get",
+      description: "Get detailed information about a cron job including recent run history.",
+      parameters: {
+        type: "object",
+        properties: {
+          jobId: { type: "string", description: "The job ID (kebab-case)" },
+        },
+        required: ["jobId"],
+      },
+      handler: async (args) => {
+        const job = readJob(extDir, state.agentName, args.jobId);
+        if (!job) return `Error: job '${args.jobId}' not found.`;
+
+        const recent = getRecentHistory(extDir, state.agentName, args.jobId, 5);
+        const historyLines = recent.length > 0
+          ? recent.map((r) =>
+              `  ${r.outcome === "success" ? "✅" : "❌"} ${r.startedAtUtc} — ${r.durationMs}ms` +
+              (r.errorMessage ? ` — ${r.errorMessage}` : "")
+            ).join("\n")
+          : "  No runs yet.";
+
+        return `**${job.name}** (${job.id})\n` +
+          `Status: ${job.status}\n` +
+          `Schedule: ${job.schedule.type}` +
+          (job.schedule.expression ? ` \`${job.schedule.expression}\`` : "") +
+          (job.schedule.timezone ? ` (${job.schedule.timezone})` : "") +
+          (job.schedule.intervalMs ? ` every ${job.schedule.intervalMs}ms` : "") +
+          `\nNext run: ${job.nextRunAtUtc || "none"}\n` +
+          `Last run: ${job.lastRunAtUtc || "never"}\n` +
+          `Payload: ${job.payload.type}` +
+          (job.payload.command ? ` — \`${job.payload.command} ${job.payload.arguments || ""}\`` : "") +
+          (job.payload.prompt ? ` — "${job.payload.prompt.slice(0, 80)}"` : "") +
+          `\nTimeout: ${job.payload.timeoutSeconds}s\n` +
+          (job.backoff ? `Backoff: ${job.backoff.consecutiveFailures} failures, retry at ${job.backoff.nextRetryAtUtc}\n` : "") +
+          `\n**Recent runs:**\n${historyLines}`;
+      },
+    },
+
+    {
+      name: "cron_update",
+      description: "Update a cron job's name, schedule, payload, or timeout. Only provide fields you want to change.",
+      parameters: {
+        type: "object",
+        properties: {
+          jobId: { type: "string", description: "The job ID to update" },
+          name: { type: "string", description: "New job name" },
+          scheduleType: { type: "string", enum: ["cron", "interval", "oneShot"], description: "New schedule type" },
+          cronExpression: { type: "string", description: "New cron expression" },
+          timezone: { type: "string", description: "New IANA timezone" },
+          intervalMs: { type: "number", description: "New interval in milliseconds" },
+          fireAtUtc: { type: "string", description: "New fire-at time (ISO 8601 UTC)" },
+          command: { type: "string", description: "New command" },
+          arguments: { type: "string", description: "New arguments" },
+          workingDirectory: { type: "string", description: "New working directory" },
+          prompt: { type: "string", description: "New prompt text" },
+          model: { type: "string", description: "New model" },
+          timeoutSeconds: { type: "number", description: "New timeout in seconds" },
+        },
+        required: ["jobId"],
+      },
+      handler: async (args) => {
+        const job = readJob(extDir, state.agentName, args.jobId);
+        if (!job) return `Error: job '${args.jobId}' not found.`;
+
+        const changes = [];
+
+        if (args.name !== undefined) {
+          job.name = args.name;
+          changes.push("name");
+        }
+
+        // Schedule updates
+        let scheduleChanged = false;
+        if (args.scheduleType !== undefined) {
+          job.schedule.type = args.scheduleType;
+          scheduleChanged = true;
+        }
+        if (args.cronExpression !== undefined) {
+          job.schedule.expression = args.cronExpression;
+          scheduleChanged = true;
+        }
+        if (args.timezone !== undefined) {
+          job.schedule.timezone = args.timezone;
+          scheduleChanged = true;
+        }
+        if (args.intervalMs !== undefined) {
+          job.schedule.intervalMs = args.intervalMs;
+          scheduleChanged = true;
+        }
+        if (args.fireAtUtc !== undefined) {
+          job.schedule.fireAtUtc = args.fireAtUtc;
+          scheduleChanged = true;
+        }
+
+        if (scheduleChanged) {
+          const validation = validateSchedule(job.schedule);
+          if (!validation.valid) return `Error: ${validation.error}`;
+          job.nextRunAtUtc = calculateNextRun(job.schedule, job.lastRunAtUtc);
+          changes.push("schedule");
+        }
+
+        // Payload updates
+        if (args.command !== undefined) { job.payload.command = args.command; changes.push("command"); }
+        if (args.arguments !== undefined) { job.payload.arguments = args.arguments; changes.push("arguments"); }
+        if (args.workingDirectory !== undefined) { job.payload.workingDirectory = args.workingDirectory; changes.push("workingDirectory"); }
+        if (args.prompt !== undefined) { job.payload.prompt = args.prompt; changes.push("prompt"); }
+        if (args.model !== undefined) { job.payload.model = args.model; changes.push("model"); }
+        if (args.timeoutSeconds !== undefined) { job.payload.timeoutSeconds = args.timeoutSeconds; changes.push("timeout"); }
+
+        if (changes.length === 0) return "No changes specified.";
+
+        writeJob(extDir, state.agentName, job);
+        return `Updated **${job.name}** (${job.id}): ${changes.join(", ")}` +
+          (scheduleChanged ? `\nNext run: ${job.nextRunAtUtc || "none"}` : "");
+      },
+    },
+
+    {
+      name: "cron_delete",
+      description: "Delete a cron job and its run history.",
+      parameters: {
+        type: "object",
+        properties: {
+          jobId: { type: "string", description: "The job ID to delete" },
+        },
+        required: ["jobId"],
+      },
+      handler: async (args) => {
+        const job = readJob(extDir, state.agentName, args.jobId);
+        if (!job) return `Error: job '${args.jobId}' not found.`;
+
+        const name = job.name;
+        deleteJob(extDir, state.agentName, args.jobId);
+        deleteHistory(extDir, state.agentName, args.jobId);
+        return `Deleted job **${name}** (${args.jobId}) and its run history.`;
+      },
+    },
+  ];
+}

--- a/.github/extensions/cron/tools/engine-control.mjs
+++ b/.github/extensions/cron/tools/engine-control.mjs
@@ -1,0 +1,166 @@
+// Engine control tools — cron_engine_start, cron_engine_stop, cron_engine_status
+
+import { spawn } from "node:child_process";
+import { readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { getLockfilePath, getDataDir, getEngineLogPath } from "../lib/paths.mjs";
+import { listJobs } from "../lib/store.mjs";
+import { migrateLegacyData } from "../lib/migration.mjs";
+
+/**
+ * Sanitize an agent name to filesystem-safe characters.
+ */
+function sanitizeAgent(name) {
+  const cleaned = (name || "").trim().replace(/[^a-zA-Z0-9_-]/g, "");
+  return cleaned.length > 0 ? cleaned : null;
+}
+
+/** Check if a PID is alive */
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read engine PID from lockfile. Returns { pid, alive } or null. */
+function readEnginePid(extDir, agentName) {
+  try {
+    const raw = readFileSync(getLockfilePath(extDir, agentName), "utf-8").trim();
+    const pid = parseInt(raw, 10);
+    if (!pid || isNaN(pid)) return null;
+    return { pid, alive: isProcessAlive(pid) };
+  } catch {
+    return null;
+  }
+}
+
+export function createEngineControlTools(extDir, state) {
+  return [
+    {
+      name: "cron_engine_start",
+      description: "Start the cron engine as a detached background process. The engine evaluates schedules and executes due jobs.",
+      parameters: {
+        type: "object",
+        properties: {
+          agent: {
+            type: "string",
+            description:
+              "Agent name for per-agent data isolation. Switches jobs, history, and engine " +
+              "to data/{agent}/. Persists for the rest of this session.",
+          },
+        },
+      },
+      handler: async (args) => {
+        // Switch agent namespace if requested
+        const newAgent = args.agent ? sanitizeAgent(args.agent) : null;
+        if (newAgent && newAgent !== state.agentName) {
+          // Stop existing engine if running under old namespace
+          const oldInfo = readEnginePid(extDir, state.agentName);
+          if (oldInfo && oldInfo.alive) {
+            try { process.kill(oldInfo.pid, "SIGTERM"); } catch { /* ok */ }
+          }
+          state.agentName = newAgent;
+          migrateLegacyData(extDir, newAgent);
+        }
+
+        // Check if already running
+        const existing = readEnginePid(extDir, state.agentName);
+        if (existing && existing.alive) {
+          return `Engine is already running (PID ${existing.pid}, agent: ${state.agentName}).`;
+        }
+
+        // Clean stale lockfile
+        if (existing && !existing.alive) {
+          try { unlinkSync(getLockfilePath(extDir, state.agentName)); } catch { /* ok */ }
+        }
+
+        const enginePath = join(extDir, "engine", "main.mjs");
+        const logPath = getEngineLogPath(extDir, state.agentName);
+
+        const child = spawn("node", [enginePath, "--agent", state.agentName], {
+          detached: true,
+          stdio: "ignore",
+          windowsHide: true,
+          cwd: extDir,
+        });
+
+        child.unref();
+        const pid = child.pid;
+
+        // Brief wait for lockfile to confirm startup
+        await new Promise((r) => setTimeout(r, 1000));
+
+        const check = readEnginePid(extDir, state.agentName);
+        if (check && check.alive) {
+          const jobs = listJobs(extDir, state.agentName);
+          return `Engine started (PID ${check.pid}, agent: ${state.agentName}). ${jobs.length} job(s) registered.`;
+        } else {
+          return `Engine process spawned (PID ${pid}) but lockfile not yet confirmed. Check \`${logPath}\` for details.`;
+        }
+      },
+    },
+
+    {
+      name: "cron_engine_stop",
+      description: "Stop the running cron engine.",
+      parameters: { type: "object", properties: {} },
+      handler: async () => {
+        const info = readEnginePid(extDir, state.agentName);
+        if (!info) return `Engine is not running (no lockfile found, agent: ${state.agentName}).`;
+        if (!info.alive) {
+          try { unlinkSync(getLockfilePath(extDir, state.agentName)); } catch { /* ok */ }
+          return `Engine was not running (stale lockfile cleaned up, agent: ${state.agentName}).`;
+        }
+
+        try {
+          process.kill(info.pid, "SIGTERM");
+        } catch (err) {
+          return `Failed to stop engine (PID ${info.pid}): ${err.message}`;
+        }
+
+        // Wait for graceful shutdown (up to 5s)
+        for (let i = 0; i < 10; i++) {
+          await new Promise((r) => setTimeout(r, 500));
+          if (!isProcessAlive(info.pid)) {
+            return `Engine stopped (PID ${info.pid}, agent: ${state.agentName}).`;
+          }
+        }
+
+        // Force kill
+        try {
+          process.kill(info.pid, "SIGKILL");
+        } catch { /* already dead */ }
+
+        try { unlinkSync(getLockfilePath(extDir, state.agentName)); } catch { /* ok */ }
+        return `Engine force-stopped (PID ${info.pid}, agent: ${state.agentName}).`;
+      },
+    },
+
+    {
+      name: "cron_engine_status",
+      description: "Check if the cron engine is running and report active job count.",
+      parameters: { type: "object", properties: {} },
+      handler: async () => {
+        const info = readEnginePid(extDir, state.agentName);
+        if (!info || !info.alive) {
+          const jobs = listJobs(extDir, state.agentName);
+          const stale = info && !info.alive ? " (stale lockfile cleaned)" : "";
+          if (info && !info.alive) {
+            try { unlinkSync(getLockfilePath(extDir, state.agentName)); } catch { /* ok */ }
+          }
+          return `Engine is **not running**${stale} (agent: ${state.agentName}).\n${jobs.length} job(s) registered.`;
+        }
+
+        const jobs = listJobs(extDir, state.agentName);
+        const enabled = jobs.filter((j) => j.status === "enabled").length;
+        const disabled = jobs.filter((j) => j.status === "disabled").length;
+
+        return `Engine is **running** (PID ${info.pid}, agent: ${state.agentName}).\n` +
+          `Jobs: ${jobs.length} total (${enabled} enabled, ${disabled} disabled)`;
+      },
+    },
+  ];
+}

--- a/.github/extensions/cron/tools/lifecycle.mjs
+++ b/.github/extensions/cron/tools/lifecycle.mjs
@@ -1,0 +1,53 @@
+// Lifecycle tools — cron_pause, cron_resume
+
+import { readJob, writeJob } from "../lib/store.mjs";
+import { calculateNextRun } from "../lib/scheduler.mjs";
+
+export function createLifecycleTools(extDir, state) {
+  return [
+    {
+      name: "cron_pause",
+      description: "Pause (disable) a cron job. The job definition is kept but it won't run until resumed.",
+      parameters: {
+        type: "object",
+        properties: {
+          jobId: { type: "string", description: "The job ID to pause" },
+        },
+        required: ["jobId"],
+      },
+      handler: async (args) => {
+        const job = readJob(extDir, state.agentName, args.jobId);
+        if (!job) return `Error: job '${args.jobId}' not found.`;
+        if (job.status === "disabled") return `Job **${job.name}** is already paused.`;
+
+        job.status = "disabled";
+        job.nextRunAtUtc = null;
+        writeJob(extDir, state.agentName, job);
+        return `Paused job **${job.name}** (${job.id}). Use cron_resume to re-enable.`;
+      },
+    },
+
+    {
+      name: "cron_resume",
+      description: "Resume a paused cron job. Recalculates the next run time.",
+      parameters: {
+        type: "object",
+        properties: {
+          jobId: { type: "string", description: "The job ID to resume" },
+        },
+        required: ["jobId"],
+      },
+      handler: async (args) => {
+        const job = readJob(extDir, state.agentName, args.jobId);
+        if (!job) return `Error: job '${args.jobId}' not found.`;
+        if (job.status === "enabled") return `Job **${job.name}** is already running.`;
+
+        job.status = "enabled";
+        job.backoff = null;
+        job.nextRunAtUtc = calculateNextRun(job.schedule, job.lastRunAtUtc);
+        writeJob(extDir, state.agentName, job);
+        return `Resumed job **${job.name}** (${job.id}).\nNext run: ${job.nextRunAtUtc || "none"}`;
+      },
+    },
+  ];
+}

--- a/.github/extensions/idea/README.md
+++ b/.github/extensions/idea/README.md
@@ -1,0 +1,71 @@
+# IDEA extension
+
+IDEA is the method: **Initiatives, Domains, Expertise, Archive**.
+
+This extension searches across all four, which makes the name do the work twice:
+
+- You are searching your **IDEA** structure
+- You are searching for **ideas**
+
+So "Search your IDEA" just works.
+
+The tool names stay provider-agnostic on purpose. QMD is the engine today. It does not need to be forever.
+
+## Setup
+
+The extension installs QMD as a local dependency. After cloning or bootstrapping your mind:
+
+```bash
+cd .github/extensions/idea
+npm install
+```
+
+Then configure at least one collection so QMD knows what to index:
+
+```bash
+npx qmd collection add domains ./domains
+npx qmd collection add initiatives ./initiatives
+npx qmd collection add expertise ./expertise
+npx qmd collection add inbox ./inbox
+npx qmd collection add working-memory ./.working-memory
+npx qmd update
+```
+
+Semantic search requires vector embeddings. The extension uses the Copilot embeddings API (no local GPU needed). After the initial index:
+
+```bash
+# From a Copilot CLI session, use the idea_reindex tool
+# Or manually: npx qmd embed
+```
+
+## Tools
+
+| Tool | What it does |
+| --- | --- |
+| `idea_search` | BM25 keyword search — exact names, IDs, phrases |
+| `idea_recall` | Semantic search via Copilot embeddings — concepts, questions |
+| `idea_reindex` | Re-scan collections from the filesystem and refresh embeddings |
+| `idea_status` | Index health: document count, staleness, and collections |
+
+## Architecture
+
+```text
+Copilot CLI
+  ← JSON-RPC →  extension.mjs (joinSession)
+                   ├── lib/qmd.mjs    → QMD SDK (local node_modules)
+                   ├── lib/embed.mjs  → Copilot /embeddings API
+                   ├── lib/token.mjs  → Windows Credential Manager
+                   └── ~/.cache/qmd/index.sqlite
+```
+
+## Authentication
+
+The extension retrieves the Copilot token from Windows Credential Manager (`copilot-cli/*` entries). This is the same token the Copilot CLI uses — no additional configuration needed.
+
+**Platform support:** Windows only for now (Credential Manager). Non-Windows support will require a different token retrieval mechanism.
+
+## Design notes
+
+- **Provider-agnostic naming**: the tools expose IDEA behavior, not QMD implementation details
+- **No global install required**: QMD ships as a local npm dependency in the extension's `package.json`
+- **Custom embedding path**: semantic search uses Copilot-backed embeddings instead of local GPU inference, making it work on any machine

--- a/.github/extensions/idea/extension.mjs
+++ b/.github/extensions/idea/extension.mjs
@@ -1,0 +1,252 @@
+import { joinSession } from "@github/copilot-sdk/extension";
+
+import { embedPendingDocuments, embedQuery } from "./lib/embed.mjs";
+import { openStore } from "./lib/qmd.mjs";
+
+function normalizeLimit(limit, fallback = 10) {
+  const value = Number(limit);
+  if (!Number.isFinite(value) || value < 1) {
+    return fallback;
+  }
+
+  return Math.min(Math.floor(value), 25);
+}
+
+function formatScore(score) {
+  return `${Math.round(score * 100)}%`;
+}
+
+function cleanSnippet(snippet) {
+  return snippet
+    .replace(/^@@\s+[^@]+@@\s*(?:\([^)]*\)\s*)?/, "")
+    .trim();
+}
+
+async function buildSnippet(store, extractSnippet, result, query) {
+  const body = await store.getDocumentBody(result.displayPath);
+  if (!body) {
+    return null;
+  }
+
+  const { line, snippet } = extractSnippet(body, query, 280, result.chunkPos);
+  return {
+    line,
+    snippet: cleanSnippet(snippet),
+  };
+}
+
+async function formatResults({ store, extractSnippet, query, results, label }) {
+  if (results.length === 0) {
+    return `No ${label} results found for "${query}".`;
+  }
+
+  const lines = [`${label} results for "${query}":`, ""];
+
+  for (const [index, result] of results.entries()) {
+    lines.push(`${index + 1}. ${result.title}`);
+    lines.push(`   Path: ${result.displayPath}`);
+    lines.push(`   Collection: ${result.collectionName}`);
+    lines.push(`   Score: ${formatScore(result.score)} (${result.source})`);
+
+    const snippet = await buildSnippet(store, extractSnippet, result, query);
+    if (snippet?.snippet) {
+      lines.push(`   Snippet (line ${snippet.line}): ${snippet.snippet.replace(/\s+/g, " ")}`);
+    }
+
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+function formatReindexResult(update, embed) {
+  const lines = [
+    "IDEA reindex complete.",
+    "",
+    `Collections scanned: ${update.collections}`,
+    `Indexed: ${update.indexed} new`,
+    `Updated: ${update.updated}`,
+    `Unchanged: ${update.unchanged}`,
+    `Removed: ${update.removed}`,
+    `Pending embeddings after scan: ${update.needsEmbedding}`,
+    "",
+    `Documents embedded: ${embed.documents}`,
+    `Chunks embedded: ${embed.chunks}`,
+    `Elapsed: ${embed.elapsedSeconds.toFixed(1)}s`,
+  ];
+
+  if (embed.force) {
+    lines.push("Mode: force re-embed");
+  }
+
+  return lines.join("\n");
+}
+
+function formatStatus(status, health, collections) {
+  const lines = [
+    "IDEA index status:",
+    "",
+    `Total documents: ${status.totalDocuments}`,
+    `Needs embedding: ${status.needsEmbedding}`,
+    `Vector index: ${status.hasVectorIndex ? "yes" : "no"}`,
+    `Days stale: ${health.daysStale ?? "unknown"}`,
+    `Collections: ${status.collections.length}`,
+    "",
+  ];
+
+  for (const collection of status.collections) {
+    const meta = collections.find((item) => item.name === collection.name);
+    const flags = [];
+    if (meta?.includeByDefault) {
+      flags.push("default");
+    }
+
+    lines.push(
+      `- ${collection.name}: ${collection.documents} docs at ${collection.path ?? "(db-only)"}`
+      + (flags.length > 0 ? ` [${flags.join(", ")}]` : ""),
+    );
+  }
+
+  return lines.join("\n");
+}
+
+await joinSession({
+  tools: [
+    {
+      name: "idea_search",
+      description: "Keyword search across the IDEA mind using BM25 lexical search.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Exact words or phrases to search for.",
+          },
+          collection: {
+            type: "string",
+            description: "Optional collection name to limit the search.",
+          },
+          limit: {
+            type: "integer",
+            description: "Maximum number of matches to return (default 10, max 25).",
+          },
+        },
+        required: ["query"],
+      },
+      handler: async (args) => {
+        const store = await openStore();
+        try {
+          const { extractSnippet } = await import("./lib/qmd.mjs");
+          const results = await store.searchLex(args.query, {
+            collection: args.collection,
+            limit: normalizeLimit(args.limit),
+          });
+
+          return await formatResults({
+            store,
+            extractSnippet,
+            query: args.query,
+            results,
+            label: "Keyword",
+          });
+        } finally {
+          await store.close();
+        }
+      },
+    },
+    {
+      name: "idea_recall",
+      description: "Semantic search across the IDEA mind using Copilot embeddings and QMD vector search.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Natural-language question or concept to recall.",
+          },
+          collection: {
+            type: "string",
+            description: "Optional collection name to limit the search.",
+          },
+          limit: {
+            type: "integer",
+            description: "Maximum number of matches to return (default 10, max 25).",
+          },
+        },
+        required: ["query"],
+      },
+      handler: async (args) => {
+        const store = await openStore();
+        try {
+          const { extractSnippet } = await import("./lib/qmd.mjs");
+          const queryVector = await embedQuery(args.query);
+          const results = await store.internal.searchVec(
+            args.query,
+            "text-embedding-3-small",
+            normalizeLimit(args.limit),
+            args.collection,
+            undefined,
+            queryVector,
+          );
+
+          return await formatResults({
+            store,
+            extractSnippet,
+            query: args.query,
+            results,
+            label: "Semantic",
+          });
+        } finally {
+          await store.close();
+        }
+      },
+    },
+    {
+      name: "idea_reindex",
+      description: "Re-scan the IDEA collections from disk and refresh Copilot-backed vector embeddings.",
+      parameters: {
+        type: "object",
+        properties: {
+          force: {
+            type: "boolean",
+            description: "Rebuild all embeddings instead of only missing ones.",
+            default: false,
+          },
+        },
+      },
+      handler: async (args) => {
+        const store = await openStore();
+        try {
+          const update = await store.update();
+          const embed = await embedPendingDocuments(store, {
+            force: Boolean(args.force),
+          });
+          return formatReindexResult(update, embed);
+        } finally {
+          await store.close();
+        }
+      },
+    },
+    {
+      name: "idea_status",
+      description: "Show IDEA index health, document counts, staleness, and configured collections.",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+      handler: async () => {
+        const store = await openStore();
+        try {
+          const [status, health, collections] = await Promise.all([
+            store.getStatus(),
+            store.getIndexHealth(),
+            store.listCollections(),
+          ]);
+          return formatStatus(status, health, collections);
+        } finally {
+          await store.close();
+        }
+      },
+    },
+  ],
+});

--- a/.github/extensions/idea/lib/embed.mjs
+++ b/.github/extensions/idea/lib/embed.mjs
@@ -1,0 +1,185 @@
+import { getToken } from "./token.mjs";
+
+export const COPILOT_API = "https://api.enterprise.githubcopilot.com/embeddings";
+export const COPILOT_MODEL = "text-embedding-3-small";
+export const DIMENSIONS = 1536;
+export const BATCH_SIZE = 25;
+export const DELAY_MS = 300;
+export const MAX_RETRIES = 3;
+
+const CHUNK_MAX_CHARS = 3600;
+const CHUNK_OVERLAP_CHARS = 540;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function extractTitle(filePath) {
+  const parts = filePath.replace(/\\/g, "/").split("/");
+  return parts[parts.length - 1]?.replace(/\.\w+$/, "") || "untitled";
+}
+
+function buildHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "Copilot-Integration-Id": "copilot-developer-cli",
+  };
+}
+
+export function chunkDocument(text) {
+  if (text.length <= CHUNK_MAX_CHARS) {
+    return [{ text, pos: 0 }];
+  }
+
+  const chunks = [];
+  let pos = 0;
+
+  while (pos < text.length) {
+    let end = Math.min(pos + CHUNK_MAX_CHARS, text.length);
+
+    if (end < text.length) {
+      const slice = text.slice(pos, end);
+      const headingMatch = slice.lastIndexOf("\n#");
+      if (headingMatch > CHUNK_MAX_CHARS * 0.4) {
+        end = pos + headingMatch + 1;
+      } else {
+        const paraBreak = slice.lastIndexOf("\n\n");
+        if (paraBreak > CHUNK_MAX_CHARS * 0.4) {
+          end = pos + paraBreak + 2;
+        } else {
+          const newline = slice.lastIndexOf("\n");
+          if (newline > CHUNK_MAX_CHARS * 0.4) {
+            end = pos + newline + 1;
+          }
+        }
+      }
+    }
+
+    chunks.push({ text: text.slice(pos, end).trim(), pos });
+    if (end >= text.length) {
+      break;
+    }
+
+    pos = Math.max(pos + 1, end - CHUNK_OVERLAP_CHARS);
+  }
+
+  return chunks.filter((chunk) => chunk.text.length > 0);
+}
+
+export async function embedQuery(text) {
+  const token = getToken();
+  const response = await fetch(COPILOT_API, {
+    method: "POST",
+    headers: buildHeaders(token),
+    body: JSON.stringify({
+      model: COPILOT_MODEL,
+      input: [text],
+      dimensions: DIMENSIONS,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Copilot embeddings API ${response.status}: ${await response.text()}`);
+  }
+
+  const { data } = await response.json();
+  return data[0].embedding;
+}
+
+export async function embedBatch(texts, token) {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
+    const response = await fetch(COPILOT_API, {
+      method: "POST",
+      headers: buildHeaders(token),
+      body: JSON.stringify({
+        model: COPILOT_MODEL,
+        input: texts,
+        dimensions: DIMENSIONS,
+      }),
+    });
+
+    if (response.status === 429) {
+      await sleep((2 ** attempt) * 1000);
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Copilot embeddings API ${response.status}: ${await response.text()}`);
+    }
+
+    const { data } = await response.json();
+    return data.map((item) => item.embedding);
+  }
+
+  throw new Error(`Copilot embeddings API failed after ${MAX_RETRIES} retries.`);
+}
+
+export async function embedPendingDocuments(store, options = {}) {
+  const force = Boolean(options.force);
+  if (force) {
+    store.internal.clearAllEmbeddings();
+  }
+
+  store.internal.ensureVecTable(DIMENSIONS);
+
+  const pending = store.internal.getHashesForEmbedding();
+  if (pending.length === 0) {
+    return {
+      force,
+      documents: 0,
+      chunks: 0,
+      elapsedSeconds: 0,
+    };
+  }
+
+  const allChunks = [];
+  for (const doc of pending) {
+    const title = extractTitle(doc.path);
+    const chunks = chunkDocument(doc.body);
+
+    for (let index = 0; index < chunks.length; index += 1) {
+      allChunks.push({
+        hash: doc.hash,
+        seq: index,
+        pos: chunks[index].pos,
+        text: `${title} | ${chunks[index].text}`,
+      });
+    }
+  }
+
+  const token = getToken();
+  const startedAt = Date.now();
+  let embedded = 0;
+
+  for (let offset = 0; offset < allChunks.length; offset += BATCH_SIZE) {
+    const batch = allChunks.slice(offset, offset + BATCH_SIZE);
+    const embeddings = await embedBatch(
+      batch.map((chunk) => chunk.text),
+      token,
+    );
+
+    for (let index = 0; index < batch.length; index += 1) {
+      store.internal.insertEmbedding(
+        batch[index].hash,
+        batch[index].seq,
+        batch[index].pos,
+        new Float32Array(embeddings[index]),
+        COPILOT_MODEL,
+        new Date().toISOString(),
+      );
+    }
+
+    embedded += batch.length;
+    if (offset + BATCH_SIZE < allChunks.length) {
+      await sleep(DELAY_MS);
+    }
+  }
+
+  return {
+    force,
+    documents: pending.length,
+    chunks: embedded,
+    elapsedSeconds: (Date.now() - startedAt) / 1000,
+  };
+}

--- a/.github/extensions/idea/lib/qmd.mjs
+++ b/.github/extensions/idea/lib/qmd.mjs
@@ -1,0 +1,102 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const IDEA_FOLDERS = ["domains", "initiatives", "expertise", "inbox"];
+
+let qmdModulePromise;
+
+export function getRepoRoot() {
+  // Extension lives at .github/extensions/idea/lib/qmd.mjs — 4 levels up.
+  const thisFile = fileURLToPath(import.meta.url);
+  const root = resolve(dirname(thisFile), "..", "..", "..", "..");
+
+  // Validate: the expected extension path should exist under root.
+  const probe = join(root, ".github", "extensions", "idea");
+  if (!existsSync(probe)) {
+    throw new Error(
+      `IDEA: derived repo root "${root}" looks wrong — expected ${probe} to exist.`,
+    );
+  }
+
+  return root;
+}
+
+export function getAgentDbPath(repoRoot) {
+  const home = process.env.USERPROFILE || process.env.HOME || homedir();
+  const name = basename(repoRoot);
+  const hash = createHash("sha256").update(resolve(repoRoot)).digest("hex").slice(0, 8);
+  const dir = join(home, ".cache", "qmd", `${name}-${hash}`);
+  mkdirSync(dir, { recursive: true });
+  return join(dir, "index.sqlite");
+}
+
+export function discoverCollections(repoRoot) {
+  const collections = {};
+  for (const folder of IDEA_FOLDERS) {
+    const folderPath = join(repoRoot, folder);
+    if (existsSync(folderPath)) {
+      collections[folder] = { path: folderPath, pattern: "**/*.md" };
+    }
+  }
+
+  if (Object.keys(collections).length === 0) {
+    throw new Error(
+      `IDEA: no collections found under "${repoRoot}". ` +
+      `Expected at least one of: ${IDEA_FOLDERS.join(", ")}`,
+    );
+  }
+
+  return { collections };
+}
+
+export async function loadQmd() {
+  if (!qmdModulePromise) {
+    qmdModulePromise = (async () => {
+      // 1. QMD_PATH env var override (escape hatch)
+      if (process.env.QMD_PATH) {
+        try {
+          const { pathToFileURL } = await import("node:url");
+          return await import(pathToFileURL(process.env.QMD_PATH).href);
+        } catch {
+          // Fall through to local node_modules.
+        }
+      }
+
+      // 2. Extension-local node_modules (installed by npm)
+      try {
+        const extDir = dirname(dirname(fileURLToPath(import.meta.url)));
+        const localPath = join(extDir, "node_modules", "@tobilu", "qmd", "dist", "index.js");
+        const { pathToFileURL } = await import("node:url");
+        return await import(pathToFileURL(localPath).href);
+      } catch {
+        // Fall through to bare specifier.
+      }
+
+      // 3. Bare specifier (works if global install is resolvable)
+      try {
+        return await import("@tobilu/qmd");
+      } catch {
+        throw new Error(
+          "Cannot find @tobilu/qmd. Run `npm install` in the idea extension directory, "
+          + "or set QMD_PATH to the QMD index.js path.",
+        );
+      }
+    })();
+  }
+
+  return qmdModulePromise;
+}
+
+export async function openStore() {
+  const { createStore } = await loadQmd();
+  const repoRoot = getRepoRoot();
+  const dbPath = getAgentDbPath(repoRoot);
+  const config = discoverCollections(repoRoot);
+  return createStore({ dbPath, config });
+}
+
+export const { extractSnippet, addLineNumbers } = await loadQmd();

--- a/.github/extensions/idea/lib/token.mjs
+++ b/.github/extensions/idea/lib/token.mjs
@@ -1,0 +1,78 @@
+import { execFileSync } from "node:child_process";
+
+const CREDENTIAL_PREFIX = "copilot-cli/";
+
+function getTokenWindows() {
+  const script = `
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+public class CredEnum {
+  [DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+  public static extern bool CredEnumerateW(string filter, int flags, out int count, out IntPtr creds);
+  [DllImport("advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+  public static extern bool CredReadW(string target, int type, int flags, out IntPtr cred);
+  [DllImport("advapi32.dll")]
+  public static extern void CredFree(IntPtr cred);
+  [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+  public struct CREDENTIAL {
+    public int Flags; public int Type; public string TargetName;
+    public string Comment; public long LastWritten; public int CredentialBlobSize;
+    public IntPtr CredentialBlob; public int Persist; public int AttributeCount;
+    public IntPtr Attributes; public string TargetAlias; public string UserName;
+  }
+  public static string GetFirst(string prefix) {
+    IntPtr creds; int count;
+    if (!CredEnumerateW(prefix + "*", 0, out count, out creds)) return null;
+    for (int i = 0; i < count; i++) {
+      IntPtr entry = Marshal.ReadIntPtr(creds, i * IntPtr.Size);
+      var c = Marshal.PtrToStructure<CREDENTIAL>(entry);
+      if (c.TargetName != null && c.TargetName.StartsWith(prefix) && c.CredentialBlobSize > 0) {
+        byte[] b = new byte[c.CredentialBlobSize];
+        Marshal.Copy(c.CredentialBlob, b, 0, c.CredentialBlobSize);
+        CredFree(creds);
+        return System.Text.Encoding.UTF8.GetString(b);
+      }
+    }
+    CredFree(creds);
+    return null;
+  }
+}
+"@
+[CredEnum]::GetFirst('${CREDENTIAL_PREFIX}')
+`;
+
+  try {
+    const token = execFileSync(
+      "powershell.exe",
+      ["-NoProfile", "-Command", script],
+      { encoding: "utf8", timeout: 15000 },
+    ).trim();
+
+    if (token) {
+      return token;
+    }
+  } catch {
+    // Credential Manager unavailable or no matching entry.
+  }
+
+  return null;
+}
+
+export function getToken() {
+  if (process.platform === "win32") {
+    const token = getTokenWindows();
+    if (token) {
+      return token;
+    }
+  }
+
+  throw new Error(
+    "Could not retrieve Copilot token. "
+    + (process.platform === "win32"
+      ? "No copilot-cli/* entry found in Windows Credential Manager."
+      : "Token retrieval is only supported on Windows via Credential Manager.")
+    + " Ensure Copilot CLI is authenticated.",
+  );
+}

--- a/.github/extensions/idea/package.json
+++ b/.github/extensions/idea/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "copilot-idea-extension",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@tobilu/qmd": "^2.0.0"
+  }
+}

--- a/.github/extensions/responses/.gitignore
+++ b/.github/extensions/responses/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+data/

--- a/.github/extensions/responses/README.md
+++ b/.github/extensions/responses/README.md
@@ -1,0 +1,595 @@
+# Responses API Extension
+
+Exposes the Copilot CLI agent as an OpenAI Responses API–compatible HTTP server.
+External clients (web UIs, mobile apps, scripts, other agents) send prompts via
+HTTP and get results back as JSON, SSE streams, or RSS feeds.
+
+**Async is the default.** `POST /v1/responses` returns `202 Accepted` with a job
+ID and RSS feed URL. The prompt executes in the background via the cron engine.
+Use `async: false` for fire-and-forget on the current session, or `stream: true`
+for SSE.
+
+## Endpoints
+
+| Method   | Path              | Description                                              |
+|----------|-------------------|----------------------------------------------------------|
+| `POST`   | `/v1/responses`   | Submit a prompt (async by default, 202 + job ID + feed)  |
+| `GET`    | `/jobs`           | List background jobs (`?status=`, `?limit=`)             |
+| `GET`    | `/jobs/:id`       | Single job detail with status timeline                   |
+| `GET`    | `/feed/:jobId`    | RSS 2.0 XML feed of job status updates                   |
+| `DELETE` | `/jobs`           | Delete all terminal jobs (completed, failed, cancelled)  |
+| `DELETE` | `/jobs/:id`       | Delete a specific job (cancels if running, then deletes) |
+| `GET`    | `/history?limit=N`| Conversation history (last N messages, or all)           |
+| `GET`    | `/health`         | Liveness check with job count and uptime                 |
+
+## Request / Response
+
+### Request Format
+
+```json
+{
+  "model": "copilot",
+  "input": "Your prompt here",
+  "instructions": "Optional system instructions",
+  "id": "my-custom-job-id",
+  "stream": false,
+  "async": true,
+  "timeout": 120000
+}
+```
+
+| Field          | Type                | Default | Description                                                    |
+|----------------|---------------------|---------|----------------------------------------------------------------|
+| `input`        | string \| array     | —       | **Required.** Prompt string or array of `{ role, content }` items |
+| `model`        | string              | `"copilot"` | Ignored by the agent; passed through in response envelope  |
+| `instructions` | string              | —       | Prepended as system context                                    |
+| `id`           | string              | auto    | Custom job ID. Auto-generated as `job_{shortUuid}` if omitted  |
+| `stream`       | boolean             | `false` | `true` → SSE streaming response                               |
+| `async`        | boolean             | `true`  | `false` → fire-and-forget on current session. Default is async background job |
+| `timeout`      | number (ms)         | `120000`| Timeout for async background jobs                              |
+| `previous_response_id` | string     | —       | Chain responses for multi-turn conversations                   |
+| `temperature`  | number              | `1.0`   | Passed through in response envelope                            |
+| `metadata`     | object              | `{}`    | Passed through in response envelope                            |
+
+**HTTP Headers:**
+
+| Header           | Description                                                    |
+|------------------|----------------------------------------------------------------|
+| `X-Agent-Name`   | Sender's agent name (e.g., `moneypenny`). Included in envelope as `from` attribute. Optional — omit if caller is not an agent. |
+
+### Default (Async Background Job)
+
+```bash
+curl -s -X POST http://127.0.0.1:15210/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"copilot","input":"Analyze the codebase and list all API endpoints"}'
+```
+
+Response (`202 Accepted`):
+
+```json
+{
+  "id": "job_a1b2c3d4e5f6g7h8",
+  "object": "response",
+  "created_at": 1710523200,
+  "status": "queued",
+  "feed_url": "http://127.0.0.1:15210/feed/job_a1b2c3d4e5f6g7h8"
+}
+```
+
+The caller polls `feed_url` or `GET /jobs/:id` for progress and results.
+
+### Fire-and-Forget (Current Session)
+
+```bash
+curl -s -X POST http://127.0.0.1:15210/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"copilot","input":"Refactor the auth module","async":false}'
+```
+
+Response (`202 Accepted`) — prompt sent to the agent's current session:
+
+```json
+{
+  "object": "response",
+  "created_at": 1710523200,
+  "status": "accepted",
+  "message": "Prompt sent to current session"
+}
+```
+
+The agent executes the prompt in its own session. No job tracking, no RSS feed —
+use `async: true` (default) if you need those. Use `stream: true` if you need
+to see the response.
+
+### Message Envelope
+
+Every prompt delivered via the Responses API is wrapped in a structured XML
+envelope. The receiving agent sees who sent the message, how it was delivered,
+and the actual content in clean, parseable sections.
+
+#### Structure
+
+```xml
+<message from="agent-name">
+  <from agent="agent-name">
+    Check your Yellow Pages (contacts.json) for context on this agent.
+  </from>
+  <delivery mode="fire-and-forget|streaming|background">
+    Transport context — informs the agent how the message arrived.
+  </delivery>
+  <content>
+    The actual message from the caller.
+  </content>
+</message>
+```
+
+- **`<from>`** — only present when the caller includes an `X-Agent-Name` HTTP header.
+  The Yellow Pages skill (`.github/skills/yellow-pages/`) maintains the agent directory.
+  If `X-Agent-Name` is not set, `<from>` is omitted (backwards compatible).
+- **`<delivery>`** — transport metadata, not a behavioral command. Describes how the
+  message arrived; the `<content>` determines what the agent should do.
+- **`<content>`** — the actual prompt/message from the caller.
+
+#### Delivery Modes
+
+**Fire-and-forget (`async: false`):**
+
+```xml
+<message from="moneypenny">
+  <from agent="moneypenny">
+    Check your Yellow Pages (contacts.json) for context on this agent.
+  </from>
+  <delivery mode="fire-and-forget">
+    The caller is not waiting for a response. Use your judgment —
+    the content determines whether action or a reply is appropriate.
+    To reply, use your Yellow Pages to reach the sender.
+  </delivery>
+  <content>
+    Hey Q — quick heads up, the deploy is running.
+  </content>
+</message>
+```
+
+**Streaming (`stream: true`):**
+
+```xml
+<message from="moneypenny">
+  <from agent="moneypenny">
+    Check your Yellow Pages (contacts.json) for context on this agent.
+  </from>
+  <delivery mode="streaming">
+    The caller is connected via SSE and receiving your output in
+    real time. Respond normally.
+  </delivery>
+  <content>
+    Explain this codebase.
+  </content>
+</message>
+```
+
+**Background job (`async: true`, default):**
+
+```xml
+<message from="moneypenny">
+  <from agent="moneypenny">
+    Check your Yellow Pages (contacts.json) for context on this agent.
+  </from>
+  <delivery mode="background" job-id="job_a1b2c3d4e5f6g7h8"
+            feed-url="http://127.0.0.1:15210/feed/job_a1b2c3d4e5f6g7h8">
+    This is a tracked background job. Your work and response are
+    captured in the feed. Complete the task described in the content.
+  </delivery>
+  <content>
+    Analyze the codebase and list all API endpoints.
+  </content>
+</message>
+```
+
+The envelope is context, not a command — the agent uses judgment about whether
+to reply, and the `<content>` drives behavior.
+
+### Streaming
+
+```bash
+curl -N -X POST http://127.0.0.1:15210/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"copilot","input":"Explain this codebase","stream":true}'
+```
+
+Returns an SSE stream following the OpenAI event sequence:
+
+```
+event: response.created
+event: response.output_item.added
+event: response.content_part.added
+event: response.output_text.delta      ← repeated for each chunk
+event: response.content_part.done
+event: response.output_item.done
+event: response.completed
+```
+
+## Background Jobs
+
+### Job Lifecycle
+
+```
+POST /v1/responses
+       │
+       ▼
+  Create one-shot cron job (fires in ~3s)
+  Create job in registry (status: queued)
+  Return 202 { id, feed_url }
+       │
+       ▼  (cron engine picks up the job)
+  Spawn new Copilot session (sessionId: {agent}-{jobId})
+  Execute prompt via session.sendAndWait()
+  Status: queued → running → completed | failed
+       │
+       ▼
+  Poll GET /jobs/:id or GET /feed/:jobId for results
+```
+
+**State machine:**
+
+```
+  queued ──▶ running ──▶ completed
+    │           │
+    │           └──────▶ failed
+    │
+    └──▶ cancelled  (via DELETE /jobs/:id)
+```
+
+- **queued** — Cron job created, waiting for the engine to pick it up.
+- **running** — Cron job has fired, agent session is executing.
+- **completed** — Agent finished successfully. Session turns and checkpoints are available.
+- **failed** — Agent errored out. Error message in status items.
+- **cancelled** — Cancelled via `DELETE /jobs/:id`. If already running, execution may continue.
+
+Status is resolved lazily on each request by merging data from the job registry,
+cron system (job file + history records), session store (turns + checkpoints),
+and progress file (tool calls, sub-agents, turn events captured during execution).
+
+### RSS Feed
+
+`GET /feed/:jobId` returns an RSS 2.0 XML feed with time-series status updates.
+During execution, the feed includes incremental updates for tool calls, sub-agent
+activity, file operations, and agent turns — not just start/end events.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Job job_a1b2c3d4 — Status Feed</title>
+    <link>http://127.0.0.1:15210/jobs/job_a1b2c3d4</link>
+    <description>Status updates for job: Analyze the codebase...</description>
+    <language>en-us</language>
+    <lastBuildDate>Thu, 15 Mar 2024 12:00:00 GMT</lastBuildDate>
+    <item>
+      <title>Job Created</title>
+      <description>Request received and queued.</description>
+      <pubDate>Thu, 15 Mar 2024 12:00:00 GMT</pubDate>
+      <guid isPermaLink="false">job_a1b2c3d4-2024-03-15T12:00:00.000Z</guid>
+    </item>
+    <item>
+      <title>Processing Started</title>
+      <description>Agent began processing.</description>
+      <pubDate>Thu, 15 Mar 2024 12:00:03 GMT</pubDate>
+      <guid isPermaLink="false">job_a1b2c3d4-2024-03-15T12:00:03.000Z</guid>
+    </item>
+    <item>
+      <title>Tool: grep</title>
+      <description>pattern: TODO|FIXME</description>
+      <pubDate>Thu, 15 Mar 2024 12:00:05 GMT</pubDate>
+      <guid isPermaLink="false">job_a1b2c3d4-2024-03-15T12:00:05.000Z</guid>
+    </item>
+    <item>
+      <title>✓ grep</title>
+      <description>Found 15 matches across 8 files</description>
+      <pubDate>Thu, 15 Mar 2024 12:00:06 GMT</pubDate>
+      <guid isPermaLink="false">job_a1b2c3d4-2024-03-15T12:00:06.000Z</guid>
+    </item>
+    <item>
+      <title>Checkpoint: Analyzing files</title>
+      <description>Found 42 source files across 8 directories.</description>
+      <pubDate>Thu, 15 Mar 2024 12:00:15 GMT</pubDate>
+      <guid isPermaLink="false">job_a1b2c3d4-2024-03-15T12:00:15.000Z</guid>
+    </item>
+    <item>
+      <title>File Edited: src/auth.ts</title>
+      <description>Edited via edit</description>
+      <pubDate>Thu, 15 Mar 2024 12:00:20 GMT</pubDate>
+      <guid isPermaLink="false">job_a1b2c3d4-2024-03-15T12:00:20.000Z</guid>
+    </item>
+    <item>
+      <title>Completed</title>
+      <description>Job finished successfully.</description>
+      <pubDate>Thu, 15 Mar 2024 12:00:30 GMT</pubDate>
+      <guid isPermaLink="false">job_a1b2c3d4-2024-03-15T12:00:30.000Z</guid>
+    </item>
+  </channel>
+</rss>
+```
+
+**Status item types:**
+
+| Source | Example titles |
+|--------|---------------|
+| Job registry | "Job Created" |
+| Session turns | "Processing Started", "Turn 1", "Turn 2" |
+| Session checkpoints | "Checkpoint: Analyzing files" |
+| Session files | "File Edited: src/auth.ts", "File Created: README.md" |
+| Progress file | "Tool: grep", "✓ grep", "✗ powershell", "Agent turn started" |
+| Progress file | "Sub-agent: explore codebase", "Sub-agent completed" |
+| Cron history | "Completed", "Failed" |
+
+Status items are built from session turns and checkpoints stored in `~/.copilot/session-store.db`.
+
+### Job Endpoints
+
+#### GET /jobs
+
+List all background jobs. Supports filtering and pagination.
+
+```bash
+# All jobs
+curl -s http://127.0.0.1:15210/jobs
+
+# Only running jobs, limit 5
+curl -s "http://127.0.0.1:15210/jobs?status=running&limit=5"
+```
+
+```json
+{
+  "jobs": [
+    {
+      "id": "job_a1b2c3d4e5f6g7h8",
+      "status": "completed",
+      "prompt": "Analyze the codebase and list all API endpoints...",
+      "createdAt": "2024-03-15T12:00:00.000Z",
+      "updatedAt": "2024-03-15T12:00:30.000Z",
+      "feed_url": "http://127.0.0.1:15210/feed/job_a1b2c3d4e5f6g7h8"
+    }
+  ]
+}
+```
+
+Prompts are truncated to 100 characters in the list view.
+
+#### GET /jobs/:id
+
+Full job detail including the complete prompt, session metadata, and status timeline.
+
+```bash
+curl -s http://127.0.0.1:15210/jobs/job_a1b2c3d4e5f6g7h8
+```
+
+```json
+{
+  "id": "job_a1b2c3d4e5f6g7h8",
+  "status": "completed",
+  "prompt": "Analyze the codebase and list all API endpoints",
+  "sessionId": "fox-job_a1b2c3d4e5f6g7h8",
+  "cronJobId": "bg-job_a1b2c3d4e5f6g7h8",
+  "createdAt": "2024-03-15T12:00:00.000Z",
+  "updatedAt": "2024-03-15T12:00:30.000Z",
+  "feed_url": "http://127.0.0.1:15210/feed/job_a1b2c3d4e5f6g7h8",
+  "statusItems": [
+    { "title": "Job Created", "description": "Request received and queued.", "timestamp": "2024-03-15T12:00:00.000Z" },
+    { "title": "Processing Started", "description": "Agent began processing.", "timestamp": "2024-03-15T12:00:03.000Z" },
+    { "title": "Completed", "description": "Job finished successfully.", "timestamp": "2024-03-15T12:00:30.000Z" }
+  ]
+}
+```
+
+#### GET /feed/:jobId
+
+RSS 2.0 XML feed for a job. See [RSS Feed](#rss-feed) above.
+
+```bash
+curl -s http://127.0.0.1:15210/feed/job_a1b2c3d4e5f6g7h8
+```
+
+#### DELETE /jobs/:id
+
+Delete a background job. If the job is running or queued, it is cancelled first
+(cron job disabled). All job files (registry + progress) are removed.
+
+```bash
+curl -s -X DELETE http://127.0.0.1:15210/jobs/job_a1b2c3d4e5f6g7h8
+```
+
+```json
+{
+  "id": "job_a1b2c3d4e5f6g7h8",
+  "status": "deleted",
+  "previousStatus": "completed",
+  "message": "Job deleted (was completed)."
+}
+```
+
+Works on any job state — queued, running, completed, failed, or cancelled.
+
+#### DELETE /jobs
+
+Bulk-delete all jobs in a terminal state (completed, failed, cancelled).
+Running and queued jobs are left untouched.
+
+```bash
+curl -s -X DELETE http://127.0.0.1:15210/jobs
+```
+
+```json
+{
+  "deleted": 5,
+  "kept": 2
+}
+```
+
+## Agent Tools
+
+| Tool                 | Description                                                                    |
+|----------------------|--------------------------------------------------------------------------------|
+| `responses_status`   | Show server status, port, job count, and all endpoint URLs                     |
+| `responses_restart`  | Start or restart the server under a named agent namespace (required `agent` param) |
+
+`responses_restart` must be called before the server will listen. It claims a
+namespace (e.g. `fox`), loads config from `data/{agent}/config.json`, and
+writes a lockfile at `data/{agent}/responses.lock`.
+
+## Architecture
+
+```
+Extension Process (one per session, killed on /clear)
+ ├── HTTP Server (127.0.0.1:{port})
+ │    ├── POST /v1/responses ──▶ 202 + cron one-shot   (default: async)
+ │    ├── POST /v1/responses ──▶ session.send() + 202   (async: false, fire-forget)
+ │    ├── POST /v1/responses ──▶ SSE stream             (stream: true)
+ │    ├── GET  /jobs          ──▶ list background jobs
+ │    ├── GET  /jobs/:id      ──▶ job detail + status items
+ │    ├── GET  /feed/:jobId   ──▶ RSS 2.0 XML feed
+ │    ├── DELETE /jobs         ──▶ bulk-delete terminal jobs
+ │    ├── DELETE /jobs/:id    ──▶ delete job (cancel if active)
+ │    ├── GET  /history       ──▶ session.getMessages()
+ │    └── GET  /health        ──▶ 200 { status, jobs, uptime }
+ └── Lockfile (data/{agent}/responses.lock)
+```
+
+### Async Flow (Default)
+
+```
+Client ──POST /v1/responses──▶ Responses Server
+                                     │
+                               create one-shot cron job
+                               create job in registry
+                                     │
+Client ◀──202 { id, feed_url }────── │  (instant)
+                                     │
+            ┌────────────────────────┘
+            ▼
+      Cron Engine (separate extension)
+            │
+      fires one-shot after ~3s
+            │
+      spawns Copilot session (custom sessionId)
+            │
+      session.sendAndWait(prompt)
+            │
+      Agent executes ──▶ tools, files, etc.
+            │
+      writes turns + checkpoints to session-store.db
+            │
+Client ──GET /jobs/:id──▶ resolveJobStatus()
+                               │
+                         merges: registry + cron history + session store
+                               │
+Client ◀──200 { status, statusItems }
+```
+
+### Fire-and-Forget Flow (`async: false`)
+
+```
+Client ──POST { async: false }──▶ Responses Server
+                                        │
+                                  session.send()  (non-blocking)
+                                        │
+Client ◀──202 Accepted──────── Responses Server
+                                        │
+                                  Copilot Agent ──▶ tools, files, etc.
+                                  (continues in background)
+```
+
+## Usage Examples
+
+### Full async workflow
+
+```bash
+PORT=15210
+
+# 1. Submit a background job
+JOB=$(curl -s -X POST http://127.0.0.1:$PORT/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"copilot","input":"List all TODO comments in the codebase"}')
+
+echo "$JOB"
+# → { "id": "job_a1b2c3d4e5f6g7h8", "status": "queued", "feed_url": "..." }
+
+JOB_ID=$(echo "$JOB" | jq -r '.id')
+
+# 2. Poll for completion
+curl -s http://127.0.0.1:$PORT/jobs/$JOB_ID | jq '.status'
+# → "queued" ... "running" ... "completed"
+
+# 3. Get the RSS feed
+curl -s http://127.0.0.1:$PORT/feed/$JOB_ID
+
+# 4. List all jobs
+curl -s http://127.0.0.1:$PORT/jobs | jq '.jobs[] | {id, status}'
+```
+
+### Custom job ID
+
+```bash
+curl -s -X POST http://127.0.0.1:15210/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"copilot","input":"Run the test suite","id":"test-run-001"}'
+```
+
+### Fire-and-forget request
+
+```bash
+curl -s -X POST http://127.0.0.1:15210/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{"model":"copilot","input":"Refactor the auth module","async":false}'
+# → 202 { "status": "accepted", "message": "Prompt sent to current session" }
+```
+
+### Health check
+
+```bash
+curl -s http://127.0.0.1:15210/health | jq
+# → { "status": "ok", "session": "connected", "port": 15210, "jobs": 3, "uptime": 1234.5 }
+```
+
+## File Structure
+
+```
+responses/
+├── extension.mjs              # Entry point — joins session, creates server
+├── package.json               # Dependencies (better-sqlite3)
+├── README.md
+├── lib/
+│   ├── server.mjs             # HTTP server, request router, all endpoint handlers
+│   ├── responses.mjs          # OpenAI envelope builders (200, 202, SSE stream)
+│   ├── job-registry.mjs       # Background job CRUD (one JSON file per job)
+│   ├── job-status.mjs         # Lazy status resolution (registry + cron + session + progress)
+│   ├── cron-bridge.mjs        # Creates one-shot cron jobs, checks engine status
+│   ├── rss-builder.mjs        # RSS 2.0 XML feed builder
+│   ├── session-reader.mjs     # Reads session turns/checkpoints/files from session-store.db
+│   ├── progress-reader.mjs    # Reads JSONL progress files (tool calls, sub-agents)
+│   ├── config.mjs             # Config loader (port, logLevel)
+│   ├── lifecycle.mjs          # Lockfile management, stale cleanup, legacy migration
+│   ├── paths.mjs              # Path helpers (data dir, lockfile, config)
+│   ├── logger.mjs             # Leveled logger
+│   └── lifecycle.test.mjs     # Tests for lifecycle module
+├── tools/
+│   └── api-tools.mjs          # Agent tools (responses_status, responses_restart)
+└── data/{agent}/              # Runtime data (created per agent namespace)
+    ├── config.json            # Port and log level config
+    ├── responses.lock         # PID + port lockfile
+    └── bg-jobs/               # One JSON file per background job
+        ├── {jobId}.json
+        └── {jobId}.progress.jsonl  # Tool call / event log (JSONL)
+```
+
+## Security
+
+The server binds to `127.0.0.1` (localhost only). It is **not** exposed to the
+network. CORS headers allow all origins for local development convenience.
+
+## Prerequisites
+
+- **Cron engine must be running** for background jobs. The server returns `503`
+  if the cron engine is not available when an async request comes in.
+- `responses_restart` must be called with an `agent` parameter before the server
+  will accept requests.

--- a/.github/extensions/responses/docs/agent-namespaces.md
+++ b/.github/extensions/responses/docs/agent-namespaces.md
@@ -1,0 +1,70 @@
+# Agent Namespaces
+
+Agent namespaces isolate data, configuration, and runtime state so multiple agents can use the responses extension without conflicts.
+
+## How the Name is Determined
+
+The agent name is provided as a **required parameter** when calling `responses_restart`. There is no default — every agent must explicitly claim a namespace before the server starts.
+
+```
+responses_restart(agent: "fox")    →  namespace: "fox"
+responses_restart(agent: "ender")  →  namespace: "ender"
+```
+
+The value is sanitized to filesystem-safe characters (`[a-zA-Z0-9_-]`). Anything else is stripped. If nothing valid remains, the tool returns an error.
+
+## Startup Flow
+
+1. Extension loads — server is created but **not started**
+2. Agent calls `responses_restart(agent: "name")` on its first turn
+3. Tool reads `data/{name}/config.json`, starts the server, writes lockfile
+4. Server is now listening and ready for requests
+
+## Directory Structure
+
+Each agent gets its own directory under `data/`:
+
+```
+.github/extensions/responses/
+├── data/
+│   ├── fox/                   ← "fox" agent namespace
+│   │   ├── config.json        ← per-agent configuration
+│   │   └── responses.lock     ← PID lockfile
+│   └── ender/                 ← "ender" namespace
+│       ├── config.json
+│       └── responses.lock
+├── extension.mjs
+├── lib/
+└── ...
+```
+
+## What's Namespaced
+
+| File | Purpose | Per-agent? |
+|------|---------|-----------|
+| `config.json` | Port, log level | ✅ Each agent can listen on a different port |
+| `responses.lock` | PID + port of running process | ✅ Each agent has its own lockfile |
+
+The extension code (`extension.mjs`, `lib/`, `tools/`) is shared — only runtime data is namespaced.
+
+## Configuration
+
+Each agent reads its own `config.json`:
+
+```json
+{
+  "port": 15212,
+  "logLevel": "info"
+}
+```
+
+| Field | Default | Valid values |
+|-------|---------|-------------|
+| `port` | `15210` | `1024`–`65535` |
+| `logLevel` | `"info"` | `"silent"`, `"error"`, `"info"`, `"debug"` |
+
+If the config file is missing or invalid, defaults are used. Different agents should use different ports to avoid conflicts.
+
+## Legacy Migration
+
+Before agent namespaces, data files lived directly in `data/` (flat structure). On first `responses_restart`, `migrateLegacyData()` moves any `data/config.json` and `data/responses.lock` into `data/{agent}/`. This is idempotent — safe to run repeatedly.

--- a/.github/extensions/responses/docs/lifecycle.md
+++ b/.github/extensions/responses/docs/lifecycle.md
@@ -1,0 +1,101 @@
+# Process Lifecycle
+
+The responses extension runs as a child process managed by the Copilot CLI. The process **is** the lifecycle unit — there is no separate server start/stop within a running process.
+
+## State Machine
+
+Two states:
+
+```
+         ┌─────────┐
+         │ STOPPED  │
+         └────┬─────┘
+    process spawns,
+    server.listen() OK
+              │
+         ┌────▼──────┐
+         │ CONNECTED  │
+         └────┬──────┘
+              │
+    SIGTERM / SIGKILL / exit
+              │
+         ┌────▼─────┐
+         │ STOPPED   │
+         └──────────┘
+```
+
+If the server is reachable, the process is alive and connected. If not, the process doesn't exist. There is no intermediate state visible to clients.
+
+## Startup Sequence
+
+Every process follows one path:
+
+```
+migrate legacy data
+  → clean stale lockfile
+    → start HTTP server
+      → write lockfile
+        → joinSession()
+          → bind session to server
+```
+
+Top-level `await` in `extension.mjs` means the process blocks until each step completes. By the time external clients can reach the server, everything is wired up.
+
+### Startup Breadcrumb
+
+A `startup.json` file is written at three milestones during startup so that crashes leave a diagnostic trace:
+
+| Stage | Written after | Crash here means |
+|-------|--------------|------------------|
+| `init` | Process entry | Import error, config error, or migration failure |
+| `server_up` | `server.start()` returns | `joinSession()` failed or session binding crashed |
+| `ready` | Session fully bound | Everything worked — process is operational |
+
+If `startup.json` is missing entirely, the CLI never forked the process.
+
+Read it with:
+```bash
+cat .github/extensions/responses/data/{agent}/startup.json
+```
+
+## /clear — Process Recycle
+
+When the user runs `/clear`, the CLI:
+
+1. Sends `SIGTERM` to the running extension process
+2. The process handles the signal: stops the server, removes the lockfile, exits
+3. The CLI forks a new process
+4. The new process runs the full startup sequence
+
+```
+CLI ──SIGTERM──► Old Process ──cleanup──► exit
+CLI ──fork────► New Process ──startup──► CONNECTED
+```
+
+The old and new processes never overlap. The lockfile is removed before the old process exits and written after the new server is listening.
+
+## Graceful Shutdown (Ctrl+C / CLI Exit)
+
+Same as `/clear` cleanup — the process receives `SIGTERM`, stops the server, removes the lockfile, and exits. The CLI escalates to `SIGKILL` after 5 seconds if the process hasn't exited.
+
+## Crash Recovery (SIGKILL / Unhandled Error)
+
+If a process dies without cleanup (SIGKILL, segfault, unhandled exception), the lockfile is left behind with a stale PID. The next process to start detects this:
+
+1. Reads the lockfile
+2. Checks if the recorded PID is still alive (`kill -0`)
+3. If dead → removes the stale lockfile and proceeds normally
+4. If alive → another instance is running; logs a warning
+
+## Extension Crash
+
+A crashed extension stays dead. There is no auto-respawn. The process restarts on the next `/clear` or `extensions_reload()`.
+
+## HTTP Behavior
+
+| Process state | `GET /health` | `POST /v1/responses` | `GET /history` |
+|--------------|--------------|---------------------|---------------|
+| Not running | Connection refused | Connection refused | Connection refused |
+| Running | `200` | `200` (normal) | `200` (history) |
+
+No `503`. No "degraded" mode. Binary: reachable or not.

--- a/.github/extensions/responses/docs/lockfile.md
+++ b/.github/extensions/responses/docs/lockfile.md
@@ -1,0 +1,51 @@
+# PID Lockfile
+
+The lockfile prevents port conflicts and enables stale process detection across restarts.
+
+## Location
+
+```
+.github/extensions/responses/data/{agent}/responses.lock
+```
+
+Where `{agent}` is the agent namespace (see [agent-namespaces.md](agent-namespaces.md)). Default: `default`.
+
+## Format
+
+```json
+{"pid":78047,"port":15210}
+```
+
+Two fields, both required:
+- **`pid`** — OS process ID of the running extension
+- **`port`** — TCP port the HTTP server is listening on
+
+## Lifecycle
+
+| Event | Lockfile action |
+|-------|----------------|
+| Server starts listening | Written (`writeLockfile`) |
+| Graceful shutdown (SIGTERM/SIGINT) | Removed (`removeLockfile`) |
+| Process crash (SIGKILL) | Left behind (stale) |
+| Next process starts | Stale lockfile detected and cleaned |
+
+The lockfile is written **after** `server.start()` succeeds and **before** `joinSession()`. This means: if a lockfile exists, the server was listening at that port when it was written.
+
+## Stale Detection
+
+On startup, `cleanStaleLockfile()` runs before the server starts:
+
+1. Read the lockfile — if missing or unparseable, nothing to do
+2. Send signal 0 to the recorded PID (`process.kill(pid, 0)`)
+3. If the process is alive → another instance is running, log and skip
+4. If the process is dead → remove the stale lockfile and proceed
+
+This handles the SIGKILL case where the process died without running its cleanup handler.
+
+## Reading the Lockfile
+
+```bash
+cat .github/extensions/responses/data/default/responses.lock
+```
+
+If the file exists and the PID is alive, the server should be reachable at the listed port. If the file is missing, either no process is running or a clean shutdown occurred.

--- a/.github/extensions/responses/extension.mjs
+++ b/.github/extensions/responses/extension.mjs
@@ -1,0 +1,44 @@
+import { approveAll } from "@github/copilot-sdk";
+import { joinSession } from "@github/copilot-sdk/extension";
+import { createChatApiServer } from "./lib/server.mjs";
+import { removeLockfile } from "./lib/lifecycle.mjs";
+import { createLogger } from "./lib/logger.mjs";
+import { getExtensionDir, getLockfilePath } from "./lib/paths.mjs";
+import { createApiTools } from "./tools/api-tools.mjs";
+
+const extDir = getExtensionDir();
+const log = createLogger("info");
+
+// Server is created but NOT started. An agent must claim a namespace
+// by calling responses_restart(agent: "name") before the server listens.
+const state = { agentName: null };
+const server = createChatApiServer(log, extDir, state);
+
+function cleanup() {
+  if (server.isRunning()) server.stop();
+  if (state.agentName) removeLockfile(getLockfilePath(extDir, state.agentName));
+}
+
+process.on("exit", cleanup);
+process.on("SIGINT", () => { cleanup(); process.exit(0); });
+process.on("SIGTERM", () => { cleanup(); process.exit(0); });
+
+const session = await joinSession({
+  onPermissionRequest: approveAll,
+
+  hooks: {
+    onSessionStart: async () => log.info("session started"),
+    onSessionEnd: async () => log.info("session ended"),
+  },
+
+  tools: createApiTools(server, extDir, state, log),
+});
+
+server.bindSession({
+  sendAndWait: session.sendAndWait.bind(session),
+  send: session.send.bind(session),
+  getMessages: session.getMessages.bind(session),
+  onEvent: session.on.bind(session),
+});
+
+log.info("responses extension loaded — awaiting agent claim via responses_restart");

--- a/.github/extensions/responses/lib/config.mjs
+++ b/.github/extensions/responses/lib/config.mjs
@@ -1,0 +1,28 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+export const DEFAULT_CONFIG = Object.freeze({ port: 15210, logLevel: "info" });
+
+const VALID_LOG_LEVELS = new Set(["silent", "error", "info", "debug"]);
+
+function isValidPort(port) {
+  return Number.isInteger(port) && port >= 1024 && port <= 65535;
+}
+
+export function loadConfig(configPath) {
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    return {
+      port: isValidPort(parsed.port) ? parsed.port : DEFAULT_CONFIG.port,
+      logLevel: VALID_LOG_LEVELS.has(parsed.logLevel) ? parsed.logLevel : DEFAULT_CONFIG.logLevel,
+    };
+  } catch {
+    return { ...DEFAULT_CONFIG };
+  }
+}
+
+export function saveConfig(configPath, config) {
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+}

--- a/.github/extensions/responses/lib/cron-bridge.mjs
+++ b/.github/extensions/responses/lib/cron-bridge.mjs
@@ -1,0 +1,89 @@
+import { readFileSync, readdirSync, writeFileSync, mkdirSync, renameSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { randomBytes } from "node:crypto";
+
+export function getCronExtDir(responsesExtDir) {
+  return resolve(responsesExtDir, "..", "cron");
+}
+
+export function getCronJobsDir(responsesExtDir, agentName) {
+  return join(getCronExtDir(responsesExtDir), "data", agentName, "jobs");
+}
+
+/**
+ * Check whether a specific agent's cron engine lockfile exists and the PID is alive.
+ */
+function checkLockfile(lockPath) {
+  try {
+    const pid = parseInt(readFileSync(lockPath, "utf-8").trim(), 10);
+    if (!pid || isNaN(pid)) return null;
+    process.kill(pid, 0);
+    return pid;
+  } catch {
+    return null;
+  }
+}
+
+export function isCronEngineRunning(responsesExtDir, agentName) {
+  const lockPath = join(getCronExtDir(responsesExtDir), "data", agentName, "engine.lock");
+  const pid = checkLockfile(lockPath);
+  return pid ? { running: true, pid } : { running: false };
+}
+
+/**
+ * Scan all agent namespaces under cron/data/ for running engine lockfiles.
+ * Returns an array of { agentName, pid } for each live engine.
+ */
+export function findRunningEngines(responsesExtDir) {
+  const dataDir = join(getCronExtDir(responsesExtDir), "data");
+  let dirs;
+  try {
+    dirs = readdirSync(dataDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+  } catch {
+    return [];
+  }
+
+  const engines = [];
+  for (const name of dirs) {
+    const pid = checkLockfile(join(dataDir, name, "engine.lock"));
+    if (pid) engines.push({ agentName: name, pid });
+  }
+  return engines;
+}
+
+export function createOneShotCronJob(responsesExtDir, agentName, { cronJobId, prompt, sessionId, model, timeoutSeconds }) {
+  const jobsDir = getCronJobsDir(responsesExtDir, agentName);
+  if (!existsSync(jobsDir)) mkdirSync(jobsDir, { recursive: true });
+
+  const fireAtUtc = new Date(Date.now() + 3000).toISOString();
+  const job = {
+    id: cronJobId,
+    name: cronJobId,
+    status: "enabled",
+    maxConcurrency: 1,
+    createdAtUtc: new Date().toISOString(),
+    createdFrom: process.cwd(),
+    lastRunAtUtc: null,
+    nextRunAtUtc: fireAtUtc,
+    schedule: { type: "oneShot", fireAtUtc },
+    payload: {
+      type: "prompt",
+      prompt,
+      model: model ?? null,
+      sessionId: sessionId ?? null,
+      preloadToolNames: null,
+      timeoutSeconds: timeoutSeconds ?? 300,
+    },
+    backoff: null,
+    source: "responses",
+  };
+
+  const filePath = join(jobsDir, `${cronJobId}.json`);
+  const tmpPath = `${filePath}.${randomBytes(6).toString("hex")}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(job, null, 2));
+  renameSync(tmpPath, filePath);
+
+  return job;
+}

--- a/.github/extensions/responses/lib/cron-bridge.test.mjs
+++ b/.github/extensions/responses/lib/cron-bridge.test.mjs
@@ -1,0 +1,238 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  getCronExtDir,
+  getCronJobsDir,
+  isCronEngineRunning,
+  findRunningEngines,
+  createOneShotCronJob,
+} from "./cron-bridge.mjs";
+
+// ---------------------------------------------------------------------------
+// getCronExtDir
+// ---------------------------------------------------------------------------
+
+describe("getCronExtDir", () => {
+  it("resolves sibling cron directory", () => {
+    const responsesExtDir = join("/fake", "extensions", "responses");
+    const result = getCronExtDir(responsesExtDir);
+    assert.ok(result.endsWith(join("extensions", "cron")));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCronJobsDir
+// ---------------------------------------------------------------------------
+
+describe("getCronJobsDir", () => {
+  it("returns correct nested path", () => {
+    const responsesExtDir = join("/fake", "extensions", "responses");
+    const result = getCronJobsDir(responsesExtDir, "fox");
+    assert.ok(result.endsWith(join("cron", "data", "fox", "jobs")));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCronEngineRunning
+// ---------------------------------------------------------------------------
+
+describe("isCronEngineRunning", () => {
+  let tmpBase;
+  let responsesExtDir;
+  const agentName = "test-agent";
+
+  before(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "cron-bridge-"));
+    responsesExtDir = join(tmpBase, "responses");
+    mkdirSync(responsesExtDir, { recursive: true });
+  });
+  after(() => { rmSync(tmpBase, { recursive: true, force: true }); });
+
+  it("returns { running: true, pid } for alive PID", () => {
+    const lockDir = join(tmpBase, "cron", "data", agentName);
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, "engine.lock"), String(process.pid));
+    const result = isCronEngineRunning(responsesExtDir, agentName);
+    assert.equal(result.running, true);
+    assert.equal(result.pid, process.pid);
+  });
+
+  it("returns { running: false } when lockfile missing", () => {
+    const result = isCronEngineRunning(responsesExtDir, "no-such-agent");
+    assert.deepEqual(result, { running: false });
+  });
+
+  it("returns { running: false } for dead PID", () => {
+    const lockDir = join(tmpBase, "cron", "data", "dead-agent");
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, "engine.lock"), "999999");
+    const result = isCronEngineRunning(responsesExtDir, "dead-agent");
+    assert.deepEqual(result, { running: false });
+  });
+
+  it("returns { running: false } for corrupt lockfile", () => {
+    const lockDir = join(tmpBase, "cron", "data", "corrupt-agent");
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, "engine.lock"), "NOT VALID");
+    const result = isCronEngineRunning(responsesExtDir, "corrupt-agent");
+    assert.deepEqual(result, { running: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findRunningEngines
+// ---------------------------------------------------------------------------
+
+describe("findRunningEngines", () => {
+  let tmpBase;
+  let responsesExtDir;
+
+  before(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "cron-scan-"));
+    responsesExtDir = join(tmpBase, "responses");
+    mkdirSync(responsesExtDir, { recursive: true });
+  });
+  after(() => { rmSync(tmpBase, { recursive: true, force: true }); });
+
+  it("returns empty array when no data dir exists", () => {
+    const result = findRunningEngines(responsesExtDir);
+    assert.deepEqual(result, []);
+  });
+
+  it("finds a single running engine", () => {
+    const lockDir = join(tmpBase, "cron", "data", "alpha");
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, "engine.lock"), String(process.pid));
+    const result = findRunningEngines(responsesExtDir);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].agentName, "alpha");
+    assert.equal(result[0].pid, process.pid);
+  });
+
+  it("skips dead PIDs and corrupt lockfiles", () => {
+    const deadDir = join(tmpBase, "cron", "data", "dead");
+    mkdirSync(deadDir, { recursive: true });
+    writeFileSync(join(deadDir, "engine.lock"), "999999");
+
+    const corruptDir = join(tmpBase, "cron", "data", "corrupt");
+    mkdirSync(corruptDir, { recursive: true });
+    writeFileSync(join(corruptDir, "engine.lock"), "GARBAGE");
+
+    const result = findRunningEngines(responsesExtDir);
+    const names = result.map((e) => e.agentName);
+    assert.ok(!names.includes("dead"));
+    assert.ok(!names.includes("corrupt"));
+  });
+
+  it("finds multiple running engines", () => {
+    const betaDir = join(tmpBase, "cron", "data", "beta");
+    mkdirSync(betaDir, { recursive: true });
+    writeFileSync(join(betaDir, "engine.lock"), String(process.pid));
+
+    const result = findRunningEngines(responsesExtDir);
+    const names = result.map((e) => e.agentName).sort();
+    assert.ok(names.includes("alpha"));
+    assert.ok(names.includes("beta"));
+    assert.ok(names.length >= 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createOneShotCronJob
+// ---------------------------------------------------------------------------
+
+describe("createOneShotCronJob", () => {
+  let tmpBase;
+  let responsesExtDir;
+  const agentName = "test-agent";
+  let job;
+  let jobFile;
+
+  before(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "cron-create-"));
+    responsesExtDir = join(tmpBase, "responses");
+    mkdirSync(responsesExtDir, { recursive: true });
+
+    job = createOneShotCronJob(responsesExtDir, agentName, {
+      cronJobId: "job-123",
+      prompt: "do the thing",
+      sessionId: "sess-abc",
+      model: "gpt-4o",
+      timeoutSeconds: 120,
+    });
+
+    const jobsDir = getCronJobsDir(responsesExtDir, agentName);
+    jobFile = join(jobsDir, "job-123.json");
+  });
+  after(() => { rmSync(tmpBase, { recursive: true, force: true }); });
+
+  it("creates a valid JSON file in the jobs directory", () => {
+    assert.ok(existsSync(jobFile));
+    const parsed = JSON.parse(readFileSync(jobFile, "utf-8"));
+    assert.equal(parsed.id, "job-123");
+  });
+
+  it("sets schedule.type to oneShot", () => {
+    assert.equal(job.schedule.type, "oneShot");
+  });
+
+  it("sets fireAtUtc approximately 3 seconds in the future", () => {
+    const fireAt = new Date(job.schedule.fireAtUtc).getTime();
+    const now = Date.now();
+    // Should be within a reasonable window: -1s to +5s from now
+    assert.ok(fireAt > now - 1000, "fireAtUtc should not be in the distant past");
+    assert.ok(fireAt < now + 5000, "fireAtUtc should be roughly 3s in the future");
+  });
+
+  it("includes sessionId in payload", () => {
+    assert.equal(job.payload.sessionId, "sess-abc");
+  });
+
+  it("sets source to responses", () => {
+    assert.equal(job.source, "responses");
+  });
+
+  it("uses cronJobId as both id and name", () => {
+    assert.equal(job.id, "job-123");
+    assert.equal(job.name, "job-123");
+  });
+
+  it("sets status to enabled", () => {
+    assert.equal(job.status, "enabled");
+  });
+
+  it("handles null model gracefully", () => {
+    const nullModelJob = createOneShotCronJob(responsesExtDir, agentName, {
+      cronJobId: "job-null-model",
+      prompt: "test",
+      sessionId: null,
+      model: null,
+      timeoutSeconds: 300,
+    });
+    assert.equal(nullModelJob.payload.model, null);
+  });
+
+  it("creates jobs directory if it doesn't exist", () => {
+    const freshBase = mkdtempSync(join(tmpdir(), "cron-fresh-"));
+    const freshResponses = join(freshBase, "responses");
+    mkdirSync(freshResponses, { recursive: true });
+
+    createOneShotCronJob(freshResponses, "new-agent", {
+      cronJobId: "job-new",
+      prompt: "hello",
+      sessionId: null,
+      model: null,
+      timeoutSeconds: 300,
+    });
+
+    const jobsDir = getCronJobsDir(freshResponses, "new-agent");
+    assert.ok(existsSync(jobsDir));
+    assert.ok(existsSync(join(jobsDir, "job-new.json")));
+
+    rmSync(freshBase, { recursive: true, force: true });
+  });
+});

--- a/.github/extensions/responses/lib/events-reader.mjs
+++ b/.github/extensions/responses/lib/events-reader.mjs
@@ -1,0 +1,267 @@
+// events-reader.mjs — Read SDK session events from events.jsonl
+//
+// The Copilot SDK writes a full event stream to:
+//   ~/.copilot/session-state/{sessionId}/events.jsonl
+//
+// This module reads that file and provides:
+//   - Typed event parsing
+//   - Response text extraction
+//   - Session status resolution
+//   - Tool call correlation (start → complete)
+
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const SESSION_STATE_DIR = join(homedir(), ".copilot", "session-state");
+
+/**
+ * Resolve the events.jsonl path for a session.
+ * @param {string} sessionId
+ * @returns {string}
+ */
+export function eventsFilePath(sessionId) {
+  return join(SESSION_STATE_DIR, sessionId, "events.jsonl");
+}
+
+/**
+ * Check if a session's events file exists.
+ * @param {string} sessionId
+ * @returns {boolean}
+ */
+export function sessionExists(sessionId) {
+  return existsSync(eventsFilePath(sessionId));
+}
+
+/**
+ * Read and parse all events from a session's events.jsonl.
+ * Skips malformed lines. Returns [] if file doesn't exist.
+ *
+ * @param {string} sessionId
+ * @returns {Array<object>} Raw event objects from the SDK
+ */
+export function readEvents(sessionId) {
+  const filePath = eventsFilePath(sessionId);
+  if (!existsSync(filePath)) return [];
+
+  const content = readFileSync(filePath, "utf-8");
+  if (!content.trim()) return [];
+
+  const events = [];
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // Skip malformed lines (partial writes during active execution)
+    }
+  }
+  return events;
+}
+
+/**
+ * Extract the final assistant response text from events.
+ * Finds the last assistant.message with non-empty content and no tool requests.
+ * Falls back to the last assistant.message with content if all have tool requests.
+ *
+ * @param {Array<object>} events
+ * @returns {string|null}
+ */
+export function extractResponse(events) {
+  const assistantMessages = events.filter(
+    (e) => e.type === "assistant.message" && e.data?.content?.trim(),
+  );
+  if (assistantMessages.length === 0) return null;
+
+  // Prefer final message without tool requests (pure text response)
+  const pureText = assistantMessages.filter(
+    (e) => !e.data.toolRequests || e.data.toolRequests.length === 0,
+  );
+  if (pureText.length > 0) return pureText[pureText.length - 1].data.content;
+
+  // Fall back to last message with content
+  return assistantMessages[assistantMessages.length - 1].data.content;
+}
+
+/**
+ * Resolve the status of a session from its events.
+ *
+ * @param {Array<object>} events
+ * @returns {"completed"|"failed"|"running"|"queued"}
+ */
+export function resolveStatus(events) {
+  if (events.length === 0) return "queued";
+
+  const shutdown = events.find((e) => e.type === "session.shutdown");
+  if (shutdown) {
+    // Check if shutdown was clean or errored
+    const type = shutdown.data?.shutdownType;
+    if (type === "error" || type === "crash") return "failed";
+    return "completed";
+  }
+
+  // Has events but no shutdown — still running
+  const hasStart = events.some((e) => e.type === "session.start");
+  return hasStart ? "running" : "queued";
+}
+
+/**
+ * Build a timeline of status items from events — suitable for RSS or JSON.
+ * Correlates tool starts with completions via toolCallId.
+ *
+ * @param {Array<object>} events
+ * @returns {Array<{title: string, description: string, timestamp: string, fullText?: string}>}
+ */
+export function buildTimeline(events) {
+  const items = [];
+  const toolStarts = new Map(); // toolCallId → event
+
+  for (const e of events) {
+    switch (e.type) {
+      case "session.start":
+        items.push({
+          title: "Session started",
+          description: `Agent: ${e.data?.sessionId || "unknown"}`,
+          timestamp: e.timestamp,
+        });
+        break;
+
+      case "user.message":
+        items.push({
+          title: "Prompt",
+          description: truncate(e.data?.content || ""),
+          timestamp: e.timestamp,
+          fullText: e.data?.content || null,
+        });
+        break;
+
+      case "assistant.turn_start":
+        items.push({
+          title: "Agent turn started",
+          description: "",
+          timestamp: e.timestamp,
+        });
+        break;
+
+      case "tool.execution_start":
+        toolStarts.set(e.data?.toolCallId, e);
+        items.push({
+          title: `Tool: ${e.data?.toolName || "unknown"}`,
+          description: summarizeToolArgs(e.data?.toolName, e.data?.arguments),
+          timestamp: e.timestamp,
+        });
+        break;
+
+      case "tool.execution_complete": {
+        const success = e.data?.success !== false;
+        const startEvt = toolStarts.get(e.data?.toolCallId);
+        const toolName = startEvt?.data?.toolName || "tool";
+        const desc = success
+          ? truncate(extractToolResult(e.data?.result))
+          : truncate(extractToolResult(e.data?.error) || "Tool execution failed");
+        items.push({
+          title: `${success ? "✓" : "✗"} ${toolName}`,
+          description: desc,
+          timestamp: e.timestamp,
+        });
+        break;
+      }
+
+      case "assistant.turn_end":
+        items.push({
+          title: "Agent turn completed",
+          description: "",
+          timestamp: e.timestamp,
+        });
+        break;
+
+      case "assistant.message": {
+        const content = e.data?.content?.trim();
+        const hasTools = e.data?.toolRequests?.length > 0;
+        // Only emit response item for pure text messages (no tool calls)
+        if (content && !hasTools) {
+          items.push({
+            title: "Response",
+            description: truncate(content),
+            timestamp: e.timestamp,
+            fullText: content,
+          });
+        }
+        break;
+      }
+
+      case "session.shutdown":
+        items.push({
+          title: "Session completed",
+          description: `${e.data?.shutdownType || "clean"} shutdown`,
+          timestamp: e.timestamp,
+        });
+        break;
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Full session read — events, status, response, timeline in one call.
+ *
+ * @param {string} sessionId
+ * @returns {{ exists: boolean, status: string, response: string|null, events: Array, timeline: Array }|null}
+ */
+export function readSession(sessionId) {
+  if (!sessionExists(sessionId)) return null;
+
+  const events = readEvents(sessionId);
+  const prompt = events.find((e) => e.type === "user.message")?.data?.content || null;
+  const response = extractResponse(events);
+  return {
+    exists: true,
+    sessionId,
+    status: resolveStatus(events),
+    response: response ? truncate(response, 500) : null,
+    fullText: response || null,
+    prompt: prompt ? truncate(prompt, 500) : null,
+    timeline: buildTimeline(events),
+    eventCount: events.length,
+  };
+}
+
+// --- Helpers ---
+
+function truncate(text, max = 200) {
+  if (!text) return "";
+  const s = String(text);
+  return s.length > max ? s.slice(0, max) + "…" : s;
+}
+
+function summarizeToolArgs(toolName, args) {
+  if (!args) return "";
+  try {
+    // For common tools, show the most relevant arg
+    if (toolName === "powershell" || toolName === "bash") return truncate(args.command || "");
+    if (toolName === "view") return args.path || "";
+    if (toolName === "edit") return args.path || "";
+    if (toolName === "create") return args.path || "";
+    if (toolName === "grep") return `${args.pattern || ""} in ${args.path || "cwd"}`;
+    if (toolName === "glob") return args.pattern || "";
+    if (toolName === "web_fetch") return args.url || "";
+    if (toolName === "report_intent") return args.intent || "";
+    // Generic: JSON stringify the args
+    return truncate(JSON.stringify(args));
+  } catch {
+    return "";
+  }
+}
+
+function extractToolResult(result) {
+  if (!result) return "";
+  if (typeof result === "string") return result;
+  if (result.content) return String(result.content);
+  if (result.text) return String(result.text);
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return "";
+  }
+}

--- a/.github/extensions/responses/lib/job-registry.mjs
+++ b/.github/extensions/responses/lib/job-registry.mjs
@@ -1,0 +1,101 @@
+// Background job registry — one JSON file per job with atomic writes.
+
+import { readFileSync, writeFileSync, unlinkSync, readdirSync, mkdirSync, renameSync } from "node:fs";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { getDataDir } from "./paths.mjs";
+
+/**
+ * Atomic write: write to temp file, then rename.
+ * Rename is atomic on both NTFS and Linux.
+ */
+function atomicWrite(filePath, data) {
+  const tmp = filePath + "." + randomBytes(6).toString("hex") + ".tmp";
+  try {
+    writeFileSync(tmp, JSON.stringify(data, null, 2), "utf-8");
+    renameSync(tmp, filePath);
+  } finally {
+    try { unlinkSync(tmp); } catch { /* tmp already renamed or never written */ }
+  }
+}
+
+/** Return the bg-jobs directory for an agent. */
+export function getBgJobsDir(extDir, agentName) {
+  return join(getDataDir(extDir, agentName), "bg-jobs");
+}
+
+/** Ensure the bg-jobs directory exists. */
+function ensureBgJobsDir(extDir, agentName) {
+  mkdirSync(getBgJobsDir(extDir, agentName), { recursive: true });
+}
+
+/** Create a new background job. Returns the job object. */
+export function createJob(extDir, agentName, { id, cronJobId, sessionId, prompt }) {
+  ensureBgJobsDir(extDir, agentName);
+  const now = new Date().toISOString();
+  const job = {
+    id,
+    cronJobId,
+    sessionId,
+    prompt,
+    status: "queued",
+    createdAt: now,
+    updatedAt: now,
+  };
+  atomicWrite(join(getBgJobsDir(extDir, agentName), `${id}.json`), job);
+  return job;
+}
+
+/** Read a single job by ID. Returns null if not found. */
+export function getJob(extDir, agentName, jobId) {
+  try {
+    const raw = readFileSync(join(getBgJobsDir(extDir, agentName), `${jobId}.json`), "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** List all jobs. Returns an array of job objects sorted by createdAt descending. */
+export function listJobs(extDir, agentName) {
+  ensureBgJobsDir(extDir, agentName);
+  const dir = getBgJobsDir(extDir, agentName);
+  const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  return files.map((f) => {
+    try {
+      return JSON.parse(readFileSync(join(dir, f), "utf-8"));
+    } catch {
+      return null;
+    }
+  }).filter(Boolean).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/** Update a job's status. Returns the updated job or null if not found. */
+export function updateJobStatus(extDir, agentName, jobId, status) {
+  const job = getJob(extDir, agentName, jobId);
+  if (!job) return null;
+  job.status = status;
+  job.updatedAt = new Date().toISOString();
+  atomicWrite(join(getBgJobsDir(extDir, agentName), `${jobId}.json`), job);
+  return job;
+}
+
+/** Delete a job by ID. Returns true if deleted, false if not found. */
+export function removeJob(extDir, agentName, jobId) {
+  try {
+    unlinkSync(join(getBgJobsDir(extDir, agentName), `${jobId}.json`));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Delete a job's progress JSONL file. Returns true if deleted, false if not found. */
+export function removeProgressFile(extDir, agentName, jobId) {
+  try {
+    unlinkSync(join(getBgJobsDir(extDir, agentName), `${jobId}.progress.jsonl`));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/.github/extensions/responses/lib/job-registry.test.mjs
+++ b/.github/extensions/responses/lib/job-registry.test.mjs
@@ -1,0 +1,195 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  getBgJobsDir,
+  createJob,
+  getJob,
+  listJobs,
+  updateJobStatus,
+  removeJob,
+} from "./job-registry.mjs";
+
+const AGENT = "test-agent";
+
+// ---------------------------------------------------------------------------
+// getBgJobsDir
+// ---------------------------------------------------------------------------
+
+describe("getBgJobsDir", () => {
+  it("returns correct path", () => {
+    const dir = getBgJobsDir("/fake/ext", "myagent");
+    assert.equal(dir, join("/fake/ext", "data", "myagent", "bg-jobs"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createJob
+// ---------------------------------------------------------------------------
+
+describe("createJob", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "jr-create-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("creates a job file on disk with correct fields", () => {
+    const job = createJob(tmp, AGENT, {
+      id: "j1",
+      cronJobId: "cron-1",
+      sessionId: "sess-1",
+      prompt: "do stuff",
+    });
+    assert.equal(job.id, "j1");
+    assert.equal(job.cronJobId, "cron-1");
+    assert.equal(job.sessionId, "sess-1");
+    assert.equal(job.prompt, "do stuff");
+
+    const filePath = join(getBgJobsDir(tmp, AGENT), "j1.json");
+    assert.ok(existsSync(filePath));
+  });
+
+  it("sets status to 'queued' and timestamps", () => {
+    const beforeTime = new Date().toISOString();
+    const job = createJob(tmp, AGENT, {
+      id: "j2",
+      cronJobId: "cron-2",
+      sessionId: "sess-2",
+      prompt: "more stuff",
+    });
+    const afterTime = new Date().toISOString();
+
+    assert.equal(job.status, "queued");
+    assert.ok(job.createdAt >= beforeTime && job.createdAt <= afterTime);
+    assert.equal(job.createdAt, job.updatedAt);
+  });
+
+  it("file is valid JSON", () => {
+    createJob(tmp, AGENT, {
+      id: "j3",
+      cronJobId: "cron-3",
+      sessionId: "sess-3",
+      prompt: "json check",
+    });
+    const raw = readFileSync(join(getBgJobsDir(tmp, AGENT), "j3.json"), "utf-8");
+    const parsed = JSON.parse(raw);
+    assert.equal(parsed.id, "j3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getJob
+// ---------------------------------------------------------------------------
+
+describe("getJob", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "jr-get-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("reads an existing job", () => {
+    createJob(tmp, AGENT, { id: "g1", cronJobId: "c", sessionId: "s", prompt: "p" });
+    const job = getJob(tmp, AGENT, "g1");
+    assert.equal(job.id, "g1");
+    assert.equal(job.status, "queued");
+  });
+
+  it("returns null for non-existent job", () => {
+    assert.equal(getJob(tmp, AGENT, "nope"), null);
+  });
+
+  it("returns null for corrupt JSON", () => {
+    const dir = getBgJobsDir(tmp, AGENT);
+    writeFileSync(join(dir, "bad.json"), "NOT VALID JSON");
+    assert.equal(getJob(tmp, AGENT, "bad"), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listJobs
+// ---------------------------------------------------------------------------
+
+describe("listJobs", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "jr-list-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("returns empty array when no jobs", () => {
+    const jobs = listJobs(tmp, AGENT);
+    assert.deepEqual(jobs, []);
+  });
+
+  it("returns jobs sorted by createdAt descending", async () => {
+    // Create 3 jobs with staggered timestamps
+    createJob(tmp, AGENT, { id: "old", cronJobId: "c", sessionId: "s", prompt: "1" });
+    await new Promise((r) => setTimeout(r, 50));
+    createJob(tmp, AGENT, { id: "mid", cronJobId: "c", sessionId: "s", prompt: "2" });
+    await new Promise((r) => setTimeout(r, 50));
+    createJob(tmp, AGENT, { id: "new", cronJobId: "c", sessionId: "s", prompt: "3" });
+
+    const jobs = listJobs(tmp, AGENT);
+    assert.equal(jobs.length, 3);
+    assert.equal(jobs[0].id, "new");
+    assert.equal(jobs[1].id, "mid");
+    assert.equal(jobs[2].id, "old");
+  });
+
+  it("skips corrupt files", () => {
+    const dir = getBgJobsDir(tmp, AGENT);
+    writeFileSync(join(dir, "corrupt.json"), "{{{{");
+    const jobs = listJobs(tmp, AGENT);
+    // Should still return the 3 valid jobs from previous test
+    assert.ok(jobs.every((j) => j.id !== "corrupt"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateJobStatus
+// ---------------------------------------------------------------------------
+
+describe("updateJobStatus", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "jr-update-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("updates status and updatedAt", async () => {
+    const original = createJob(tmp, AGENT, { id: "u1", cronJobId: "c", sessionId: "s", prompt: "p" });
+    await new Promise((r) => setTimeout(r, 50));
+    const updated = updateJobStatus(tmp, AGENT, "u1", "running");
+    assert.equal(updated.status, "running");
+    assert.ok(updated.updatedAt > original.updatedAt);
+  });
+
+  it("returns null for non-existent job", () => {
+    assert.equal(updateJobStatus(tmp, AGENT, "ghost", "running"), null);
+  });
+
+  it("preserves other fields", () => {
+    createJob(tmp, AGENT, { id: "u2", cronJobId: "cron-x", sessionId: "sess-x", prompt: "keep me" });
+    const updated = updateJobStatus(tmp, AGENT, "u2", "completed");
+    assert.equal(updated.cronJobId, "cron-x");
+    assert.equal(updated.sessionId, "sess-x");
+    assert.equal(updated.prompt, "keep me");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeJob
+// ---------------------------------------------------------------------------
+
+describe("removeJob", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "jr-remove-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("removes existing job, returns true", () => {
+    createJob(tmp, AGENT, { id: "r1", cronJobId: "c", sessionId: "s", prompt: "p" });
+    assert.equal(removeJob(tmp, AGENT, "r1"), true);
+    assert.equal(getJob(tmp, AGENT, "r1"), null);
+  });
+
+  it("returns false for non-existent job", () => {
+    assert.equal(removeJob(tmp, AGENT, "nope"), false);
+  });
+});

--- a/.github/extensions/responses/lib/job-status.mjs
+++ b/.github/extensions/responses/lib/job-status.mjs
@@ -1,0 +1,128 @@
+// Lazy job-status resolution — merges registry, cron, and session data
+// into a unified timeline on each request.
+
+import { readFileSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { buildStatusItemsFromSession } from "./session-reader.mjs";
+import { getJob, updateJobStatus, getBgJobsDir } from "./job-registry.mjs";
+import { readProgressEvents } from "./progress-reader.mjs";
+
+/**
+ * Read and parse a JSON file. Returns null on any failure.
+ */
+function readJson(filePath) {
+  try {
+    if (!existsSync(filePath)) return null;
+    return JSON.parse(readFileSync(filePath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the most recent run record from the cron history file.
+ * History is an array of { outcome, startedAtUtc, completedAtUtc, errorMessage, durationMs, output }.
+ * Returns the last entry or null.
+ */
+function readLatestHistoryRecord(extDir, agentName, cronJobId) {
+  const historyPath = resolve(extDir, "..", "cron", "data", agentName, "history", `${cronJobId}.json`);
+  const records = readJson(historyPath);
+  if (!Array.isArray(records) || records.length === 0) return null;
+  return records[records.length - 1];
+}
+
+/**
+ * Check whether a one-shot cron job has fired.
+ * A one-shot is considered fired when its status is "disabled".
+ */
+function hasCronJobFired(extDir, agentName, cronJobId) {
+  const jobPath = resolve(extDir, "..", "cron", "data", agentName, "jobs", `${cronJobId}.json`);
+  const cronJob = readJson(jobPath);
+  if (!cronJob) return false;
+  return cronJob.status === "disabled" && cronJob.schedule?.type === "oneShot";
+}
+
+/**
+ * Resolve the current status of a background job by merging data from
+ * the job registry, cron system, and session store into a unified timeline.
+ *
+ * Returns { status, statusItems, response } or null if the job doesn't exist.
+ * `response` contains the full output text when available (from session store
+ * turns or cron history), or null.
+ */
+export function resolveJobStatus(extDir, agentName, jobId) {
+  const job = getJob(extDir, agentName, jobId);
+  if (!job) return null;
+
+  const statusItems = [
+    { title: "Job Created", description: "Request received and queued.", timestamp: job.createdAt },
+  ];
+
+  // Cron execution data
+  const historyRecord = readLatestHistoryRecord(extDir, agentName, job.cronJobId);
+  const cronFired = hasCronJobFired(extDir, agentName, job.cronJobId);
+
+  // Session progress data
+  const sessionItems = buildStatusItemsFromSession(job.sessionId);
+  statusItems.push(...sessionItems);
+
+  // Progress file data (tool calls, sub-agents, turn events)
+  const progressFilePath = join(getBgJobsDir(extDir, agentName), `${jobId}.progress.jsonl`);
+  const progressItems = readProgressEvents(progressFilePath);
+  statusItems.push(...progressItems);
+
+  // Determine resolved status and capture response text
+  let resolvedStatus;
+  let response = null;
+
+  if (job.status === "cancelled") {
+    resolvedStatus = "cancelled";
+  } else if (historyRecord?.outcome === "success") {
+    resolvedStatus = "completed";
+
+    // Prefer session-store turns for response text; fall back to progress file, then cron history
+    const lastTurn = sessionItems.filter((i) => i.fullText).pop();
+    const lastProgress = progressItems.filter((i) => i.fullText).pop();
+    response = lastTurn?.fullText || lastProgress?.fullText || historyRecord.output || null;
+
+    // When session store is empty, surface the response from cron history
+    if (!lastTurn && historyRecord.output) {
+      statusItems.push({
+        title: "Response",
+        description: historyRecord.output,
+        timestamp: historyRecord.completedAtUtc,
+        fullText: historyRecord.output,
+      });
+    }
+
+    statusItems.push({
+      title: "Completed",
+      description: "Job finished successfully.",
+      timestamp: historyRecord.completedAtUtc,
+    });
+  } else if (historyRecord?.outcome === "failure") {
+    resolvedStatus = "failed";
+    statusItems.push({
+      title: "Failed",
+      description: historyRecord.errorMessage ?? "Unknown error.",
+      timestamp: historyRecord.completedAtUtc,
+    });
+  } else if (cronFired) {
+    resolvedStatus = "running";
+  } else {
+    resolvedStatus = "queued";
+  }
+
+  // Sync registry if status drifted (but never override a cancellation)
+  if (resolvedStatus !== job.status && job.status !== "cancelled") {
+    updateJobStatus(extDir, agentName, jobId, resolvedStatus);
+  }
+
+  statusItems.sort((a, b) => {
+    if (a.timestamp < b.timestamp) return -1;
+    if (a.timestamp > b.timestamp) return 1;
+    return 0;
+  });
+
+  return { status: resolvedStatus, statusItems, response };
+}

--- a/.github/extensions/responses/lib/job-status.test.mjs
+++ b/.github/extensions/responses/lib/job-status.test.mjs
@@ -1,0 +1,199 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+
+import { resolveJobStatus } from "./job-status.mjs";
+
+function writeJson(filePath, data) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, JSON.stringify(data, null, 2));
+}
+
+// Helpers to build paths matching the module's expectations
+function jobRegistryPath(extDir, agent, jobId) {
+  return join(extDir, "data", agent, "bg-jobs", `${jobId}.json`);
+}
+function cronJobPath(extDir, agent, cronJobId) {
+  return join(extDir, "..", "cron", "data", agent, "jobs", `${cronJobId}.json`);
+}
+function cronHistoryPath(extDir, agent, cronJobId) {
+  return join(extDir, "..", "cron", "data", agent, "history", `${cronJobId}.json`);
+}
+
+function makeJob(overrides = {}) {
+  return {
+    id: "job-1",
+    cronJobId: "cron-1",
+    sessionId: "sess-1",
+    prompt: "do stuff",
+    status: "queued",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+const AGENT = "test-agent";
+
+describe("resolveJobStatus", () => {
+  let tmpBase;
+  let extDir;
+
+  before(() => {
+    tmpBase = mkdtempSync(join(tmpdir(), "job-status-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(extDir, { recursive: true });
+  });
+
+  after(() => {
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns null when job doesn't exist in registry", () => {
+    const result = resolveJobStatus(extDir, AGENT, "nonexistent");
+    assert.equal(result, null);
+  });
+
+  it('returns "queued" when job exists but cron hasn\'t fired', () => {
+    const job = makeJob({ id: "q1", cronJobId: "cron-q1" });
+    writeJson(jobRegistryPath(extDir, AGENT, "q1"), job);
+    writeJson(cronJobPath(extDir, AGENT, "cron-q1"), {
+      status: "enabled",
+      schedule: { type: "oneShot" },
+    });
+
+    const result = resolveJobStatus(extDir, AGENT, "q1");
+    assert.equal(result.status, "queued");
+    assert.ok(result.statusItems.some((s) => s.title === "Job Created"));
+  });
+
+  it('returns "running" when cron job has fired but no history', () => {
+    const job = makeJob({ id: "r1", cronJobId: "cron-r1" });
+    writeJson(jobRegistryPath(extDir, AGENT, "r1"), job);
+    writeJson(cronJobPath(extDir, AGENT, "cron-r1"), {
+      status: "disabled",
+      schedule: { type: "oneShot" },
+    });
+    // no history file
+
+    const result = resolveJobStatus(extDir, AGENT, "r1");
+    assert.equal(result.status, "running");
+  });
+
+  it('returns "completed" when history has success outcome', () => {
+    const job = makeJob({ id: "c1", cronJobId: "cron-c1" });
+    writeJson(jobRegistryPath(extDir, AGENT, "c1"), job);
+    writeJson(cronHistoryPath(extDir, AGENT, "cron-c1"), [
+      { outcome: "success", completedAtUtc: "2025-01-01T01:00:00.000Z" },
+    ]);
+
+    const result = resolveJobStatus(extDir, AGENT, "c1");
+    assert.equal(result.status, "completed");
+    assert.ok(result.statusItems.some((s) => s.title === "Completed"));
+  });
+
+  it('returns "failed" when history has failure outcome', () => {
+    const job = makeJob({ id: "f1", cronJobId: "cron-f1" });
+    writeJson(jobRegistryPath(extDir, AGENT, "f1"), job);
+    writeJson(cronHistoryPath(extDir, AGENT, "cron-f1"), [
+      { outcome: "failure", errorMessage: "timeout", completedAtUtc: "2025-01-01T01:00:00.000Z" },
+    ]);
+
+    const result = resolveJobStatus(extDir, AGENT, "f1");
+    assert.equal(result.status, "failed");
+    const failItem = result.statusItems.find((s) => s.title === "Failed");
+    assert.ok(failItem);
+    assert.ok(failItem.description.includes("timeout"));
+  });
+
+  it('preserves "cancelled" status even if cron completed', () => {
+    const job = makeJob({ id: "x1", cronJobId: "cron-x1", status: "cancelled" });
+    writeJson(jobRegistryPath(extDir, AGENT, "x1"), job);
+    writeJson(cronHistoryPath(extDir, AGENT, "cron-x1"), [
+      { outcome: "success", completedAtUtc: "2025-01-01T01:00:00.000Z" },
+    ]);
+
+    const result = resolveJobStatus(extDir, AGENT, "x1");
+    assert.equal(result.status, "cancelled");
+  });
+
+  it("syncs registry status when it drifts (side effect)", () => {
+    const job = makeJob({ id: "d1", cronJobId: "cron-d1", status: "queued" });
+    writeJson(jobRegistryPath(extDir, AGENT, "d1"), job);
+    writeJson(cronHistoryPath(extDir, AGENT, "cron-d1"), [
+      { outcome: "success", completedAtUtc: "2025-01-01T01:00:00.000Z" },
+    ]);
+
+    const result = resolveJobStatus(extDir, AGENT, "d1");
+    assert.equal(result.status, "completed");
+
+    // Re-read the registry file to confirm it was updated
+    const updated = JSON.parse(readFileSync(jobRegistryPath(extDir, AGENT, "d1"), "utf-8"));
+    assert.equal(updated.status, "completed");
+  });
+
+  it('does NOT override "cancelled" in registry', () => {
+    const job = makeJob({ id: "nc1", cronJobId: "cron-nc1", status: "cancelled" });
+    writeJson(jobRegistryPath(extDir, AGENT, "nc1"), job);
+    writeJson(cronHistoryPath(extDir, AGENT, "cron-nc1"), [
+      { outcome: "success", completedAtUtc: "2025-01-01T01:00:00.000Z" },
+    ]);
+
+    resolveJobStatus(extDir, AGENT, "nc1");
+
+    const persisted = JSON.parse(readFileSync(jobRegistryPath(extDir, AGENT, "nc1"), "utf-8"));
+    assert.equal(persisted.status, "cancelled");
+  });
+
+  it("statusItems are sorted by timestamp", () => {
+    const job = makeJob({
+      id: "s1",
+      cronJobId: "cron-s1",
+      createdAt: "2025-01-01T02:00:00.000Z",
+    });
+    writeJson(jobRegistryPath(extDir, AGENT, "s1"), job);
+    writeJson(cronHistoryPath(extDir, AGENT, "cron-s1"), [
+      { outcome: "success", completedAtUtc: "2025-01-01T01:00:00.000Z" },
+    ]);
+
+    const result = resolveJobStatus(extDir, AGENT, "s1");
+    for (let i = 1; i < result.statusItems.length; i++) {
+      assert.ok(
+        result.statusItems[i - 1].timestamp <= result.statusItems[i].timestamp,
+        `statusItems[${i - 1}].timestamp (${result.statusItems[i - 1].timestamp}) should be <= statusItems[${i}].timestamp (${result.statusItems[i].timestamp})`
+      );
+    }
+  });
+
+  it("merges progress file events into statusItems", () => {
+    const job = makeJob({ id: "p1", cronJobId: "cron-p1" });
+    writeJson(jobRegistryPath(extDir, AGENT, "p1"), job);
+    writeJson(cronJobPath(extDir, AGENT, "cron-p1"), {
+      status: "disabled",
+      schedule: { type: "oneShot" },
+    });
+
+    // Write a progress JSONL file
+    const progressPath = join(extDir, "data", AGENT, "bg-jobs", "p1.progress.jsonl");
+    const lines = [
+      JSON.stringify({ type: "tool_start", title: "Tool: grep", description: "searching", timestamp: "2025-01-01T00:00:02.000Z" }),
+      JSON.stringify({ type: "tool_complete", title: "✓ grep", description: "found 5 matches", timestamp: "2025-01-01T00:00:03.000Z" }),
+    ];
+    writeFileSync(progressPath, lines.join("\n") + "\n");
+
+    const result = resolveJobStatus(extDir, AGENT, "p1");
+    assert.ok(result.statusItems.some((s) => s.title === "Tool: grep"), "should include tool_start from progress file");
+    assert.ok(result.statusItems.some((s) => s.title === "✓ grep"), "should include tool_complete from progress file");
+  });
+
+  it("handles missing progress file gracefully", () => {
+    const job = makeJob({ id: "np1", cronJobId: "cron-np1" });
+    writeJson(jobRegistryPath(extDir, AGENT, "np1"), job);
+
+    const result = resolveJobStatus(extDir, AGENT, "np1");
+    assert.ok(result);
+    assert.ok(Array.isArray(result.statusItems));
+  });
+});

--- a/.github/extensions/responses/lib/lifecycle.mjs
+++ b/.github/extensions/responses/lib/lifecycle.mjs
@@ -1,0 +1,84 @@
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync, renameSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const noopLogger = { debug() {}, info() {}, error() {} };
+
+export function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readLockfile(lockPath) {
+  try {
+    const raw = readFileSync(lockPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.pid === "number" && typeof parsed.port === "number") {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeLockfile(lockPath, pid, port) {
+  mkdirSync(dirname(lockPath), { recursive: true });
+  writeFileSync(lockPath, JSON.stringify({ pid, port }) + "\n");
+}
+
+export function removeLockfile(lockPath) {
+  try {
+    unlinkSync(lockPath);
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+}
+
+/**
+ * Detect and remove a stale lockfile left by a previous process that died
+ * without cleanup (e.g. SIGKILL). If the lockfile's PID is still alive,
+ * it belongs to another running instance — leave it alone.
+ */
+export function cleanStaleLockfile(lockPath, log = noopLogger) {
+  const lock = readLockfile(lockPath);
+  if (!lock) return;
+
+  if (isProcessAlive(lock.pid)) {
+    log.info(`another instance running (pid ${lock.pid}, port ${lock.port})`);
+    return;
+  }
+
+  log.info("cleaning stale lockfile");
+  removeLockfile(lockPath);
+}
+
+/**
+ * Migrate legacy flat data/config.json and data/responses.lock into the
+ * namespaced data/{agentName}/ directory.  Idempotent — safe to call every
+ * session.  If the target file already exists the old copy is simply removed.
+ */
+export function migrateLegacyData(extDir, agentName) {
+  const targetDir = join(extDir, "data", agentName);
+  mkdirSync(targetDir, { recursive: true });
+
+  for (const filename of ["config.json", "responses.lock"]) {
+    const oldPath = join(extDir, "data", filename);
+    const newPath = join(targetDir, filename);
+
+    if (!existsSync(oldPath)) continue;
+
+    try {
+      if (existsSync(newPath)) {
+        unlinkSync(oldPath);
+      } else {
+        renameSync(oldPath, newPath);
+      }
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+  }
+}

--- a/.github/extensions/responses/lib/lifecycle.test.mjs
+++ b/.github/extensions/responses/lib/lifecycle.test.mjs
@@ -1,0 +1,418 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { request } from "node:http";
+
+import { createLogger } from "./logger.mjs";
+import { loadConfig, saveConfig, DEFAULT_CONFIG } from "./config.mjs";
+import { createChatApiServer } from "./server.mjs";
+import {
+  isProcessAlive,
+  readLockfile,
+  writeLockfile,
+  removeLockfile,
+  cleanStaleLockfile,
+  migrateLegacyData,
+} from "./lifecycle.mjs";
+
+// ---------------------------------------------------------------------------
+// config.mjs
+// ---------------------------------------------------------------------------
+
+describe("loadConfig", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "resp-cfg-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("returns DEFAULT_CONFIG when file is missing", () => {
+    const cfg = loadConfig(join(tmp, "nope.json"));
+    assert.deepEqual(cfg, DEFAULT_CONFIG);
+  });
+
+  it("reads a valid config", () => {
+    const p = join(tmp, "good.json");
+    saveConfig(p, { port: 9999, logLevel: "debug" });
+    assert.deepEqual(loadConfig(p), { port: 9999, logLevel: "debug" });
+  });
+
+  it("falls back on invalid port (too low)", () => {
+    const p = join(tmp, "low.json");
+    saveConfig(p, { port: 80 });
+    assert.deepEqual(loadConfig(p), { port: DEFAULT_CONFIG.port, logLevel: "info" });
+  });
+
+  it("falls back on invalid port (non-integer)", () => {
+    const p = join(tmp, "float.json");
+    saveConfig(p, { port: 3.14 });
+    assert.deepEqual(loadConfig(p), { port: DEFAULT_CONFIG.port, logLevel: "info" });
+  });
+
+  it("falls back on corrupt JSON", () => {
+    const p = join(tmp, "corrupt.json");
+    writeFileSync(p, "NOT JSON");
+    assert.deepEqual(loadConfig(p), DEFAULT_CONFIG);
+  });
+});
+
+describe("saveConfig", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "resp-cfg-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("creates parent directories and writes JSON", () => {
+    const p = join(tmp, "sub", "dir", "config.json");
+    saveConfig(p, { port: 15212 });
+    const written = JSON.parse(readFileSync(p, "utf-8"));
+    assert.equal(written.port, 15212);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logger.mjs
+// ---------------------------------------------------------------------------
+
+describe("createLogger", () => {
+  it("returns all methods at debug level", () => {
+    const log = createLogger("debug");
+    assert.equal(log.level, "debug");
+    assert.equal(typeof log.debug, "function");
+    assert.equal(typeof log.info, "function");
+    assert.equal(typeof log.error, "function");
+  });
+
+  it("silences debug at info level", () => {
+    const log = createLogger("info");
+    assert.equal(log.level, "info");
+    // debug should be a noop — confirm it doesn't throw
+    log.debug("should not appear");
+  });
+
+  it("silences info and debug at error level", () => {
+    const log = createLogger("error");
+    assert.equal(log.level, "error");
+    log.info("noop");
+    log.debug("noop");
+  });
+
+  it("silences everything at silent level", () => {
+    const log = createLogger("silent");
+    assert.equal(log.level, "silent");
+    log.error("noop");
+    log.info("noop");
+    log.debug("noop");
+  });
+
+  it("defaults to info on invalid level", () => {
+    const log = createLogger("banana");
+    assert.equal(log.level, "info");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// config.mjs — logLevel validation
+// ---------------------------------------------------------------------------
+
+describe("loadConfig logLevel", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "resp-log-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("reads valid logLevel", () => {
+    const p = join(tmp, "debug.json");
+    saveConfig(p, { port: 15210, logLevel: "debug" });
+    assert.equal(loadConfig(p).logLevel, "debug");
+  });
+
+  it("falls back on invalid logLevel", () => {
+    const p = join(tmp, "bad.json");
+    saveConfig(p, { port: 15210, logLevel: "banana" });
+    assert.equal(loadConfig(p).logLevel, "info");
+  });
+
+  it("falls back when logLevel is missing", () => {
+    const p = join(tmp, "missing.json");
+    saveConfig(p, { port: 15210 });
+    assert.equal(loadConfig(p).logLevel, "info");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lifecycle.mjs — pure functions
+// ---------------------------------------------------------------------------
+
+describe("isProcessAlive", () => {
+  it("returns true for current process", () => {
+    assert.equal(isProcessAlive(process.pid), true);
+  });
+
+  it("returns false for bogus PID", () => {
+    assert.equal(isProcessAlive(999999), false);
+  });
+});
+
+describe("lockfile round-trip", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "resp-lock-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("write → read → remove", () => {
+    const lp = join(tmp, "data", "responses.lock");
+    assert.equal(readLockfile(lp), null);
+
+    writeLockfile(lp, 12345, 15212);
+    const lock = readLockfile(lp);
+    assert.equal(lock.pid, 12345);
+    assert.equal(lock.port, 15212);
+
+    removeLockfile(lp);
+    assert.equal(readLockfile(lp), null);
+  });
+
+  it("removeLockfile is idempotent", () => {
+    const lp = join(tmp, "gone.lock");
+    assert.doesNotThrow(() => removeLockfile(lp));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lifecycle.mjs — migrateLegacyData
+// ---------------------------------------------------------------------------
+
+describe("migrateLegacyData", () => {
+  let tmp;
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "resp-mig-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("moves legacy config.json into namespaced dir", () => {
+    const extDir = join(tmp, "ext-a");
+    mkdirSync(join(extDir, "data"), { recursive: true });
+    writeFileSync(join(extDir, "data", "config.json"), '{"port":15212}');
+
+    migrateLegacyData(extDir, "fox");
+
+    assert.equal(existsSync(join(extDir, "data", "config.json")), false);
+    assert.equal(existsSync(join(extDir, "data", "fox", "config.json")), true);
+    const content = JSON.parse(readFileSync(join(extDir, "data", "fox", "config.json"), "utf-8"));
+    assert.equal(content.port, 15212);
+  });
+
+  it("moves legacy responses.lock into namespaced dir", () => {
+    const extDir = join(tmp, "ext-b");
+    mkdirSync(join(extDir, "data"), { recursive: true });
+    writeFileSync(join(extDir, "data", "responses.lock"), '{"pid":1,"port":9999}');
+
+    migrateLegacyData(extDir, "ender");
+
+    assert.equal(existsSync(join(extDir, "data", "responses.lock")), false);
+    assert.equal(existsSync(join(extDir, "data", "ender", "responses.lock")), true);
+  });
+
+  it("deletes old file when namespaced target already exists", () => {
+    const extDir = join(tmp, "ext-c");
+    mkdirSync(join(extDir, "data", "elliot"), { recursive: true });
+    writeFileSync(join(extDir, "data", "config.json"), '{"port":1111}');
+    writeFileSync(join(extDir, "data", "elliot", "config.json"), '{"port":2222}');
+
+    migrateLegacyData(extDir, "elliot");
+
+    assert.equal(existsSync(join(extDir, "data", "config.json")), false);
+    const content = JSON.parse(readFileSync(join(extDir, "data", "elliot", "config.json"), "utf-8"));
+    assert.equal(content.port, 2222); // namespaced copy wins
+  });
+
+  it("is idempotent — no-op when no legacy files exist", () => {
+    const extDir = join(tmp, "ext-d");
+    assert.doesNotThrow(() => migrateLegacyData(extDir, "default"));
+    assert.equal(existsSync(join(extDir, "data", "default")), true);
+  });
+
+  it("handles both files at once", () => {
+    const extDir = join(tmp, "ext-e");
+    mkdirSync(join(extDir, "data"), { recursive: true });
+    writeFileSync(join(extDir, "data", "config.json"), '{"port":5555}');
+    writeFileSync(join(extDir, "data", "responses.lock"), '{"pid":42,"port":5555}');
+
+    migrateLegacyData(extDir, "fox");
+
+    assert.equal(existsSync(join(extDir, "data", "config.json")), false);
+    assert.equal(existsSync(join(extDir, "data", "responses.lock")), false);
+    assert.equal(existsSync(join(extDir, "data", "fox", "config.json")), true);
+    assert.equal(existsSync(join(extDir, "data", "fox", "responses.lock")), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// lifecycle.mjs — cleanStaleLockfile
+// ---------------------------------------------------------------------------
+
+describe("cleanStaleLockfile", () => {
+  let tmp;
+  const log = createLogger("silent");
+  before(() => { tmp = mkdtempSync(join(tmpdir(), "resp-stale-")); });
+  after(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it("removes lockfile with dead PID", () => {
+    const lp = join(tmp, "dead.lock");
+    writeLockfile(lp, 999999, 9001);
+    cleanStaleLockfile(lp, log);
+    assert.equal(readLockfile(lp), null);
+  });
+
+  it("leaves lockfile with live PID", () => {
+    const lp = join(tmp, "live.lock");
+    writeLockfile(lp, process.pid, 9002);
+    cleanStaleLockfile(lp, log);
+    const lock = readLockfile(lp);
+    assert.equal(lock.pid, process.pid);
+  });
+
+  it("is a no-op when no lockfile exists", () => {
+    const lp = join(tmp, "nope.lock");
+    assert.doesNotThrow(() => cleanStaleLockfile(lp, log));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// server.mjs — session guard (503 when deps are null)
+// ---------------------------------------------------------------------------
+
+function httpGet(port, path) {
+  return new Promise((resolve, reject) => {
+    const req = request({ hostname: "127.0.0.1", port, path, method: "GET" }, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => {
+        resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+      });
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function httpPost(port, path, body) {
+  return new Promise((resolve, reject) => {
+    const payload = JSON.stringify(body);
+    const req = request({
+      hostname: "127.0.0.1", port, path, method: "POST",
+      headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) },
+    }, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => {
+        resolve({ status: res.statusCode, body: JSON.parse(Buffer.concat(chunks).toString()) });
+      });
+    });
+    req.on("error", reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+describe("server with bindSession", () => {
+  const log = createLogger("silent");
+  let server;
+  let port;
+  let tmpDir;
+  const state = { agentName: "test" };
+
+  before(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "resp-srv-"));
+    mkdirSync(join(tmpDir, "data", "test", "bg-jobs"), { recursive: true });
+    server = createChatApiServer(log, tmpDir, state);
+    port = await server.start(0);
+    server.bindSession({
+      sendAndWait: async () => ({ data: { content: "test response" } }),
+      send: async () => {},
+      getMessages: async () => [{ role: "user", content: "hi" }],
+      onEvent: () => () => {},
+    });
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns session: connected on GET /health", async () => {
+    const res = await httpGet(port, "/health");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.session, "connected");
+  });
+
+  it("succeeds on POST /v1/responses with async: false", async () => {
+    const res = await httpPost(port, "/v1/responses", { input: "hello", async: false });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.output_text, "test response");
+  });
+
+  it("returns history on GET /history", async () => {
+    const res = await httpGet(port, "/history");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.messages.length, 1);
+  });
+
+  it("returns 400 on missing input", async () => {
+    const res = await httpPost(port, "/v1/responses", {});
+    assert.equal(res.status, 400);
+  });
+
+  it("returns 404 on unknown path", async () => {
+    const res = await httpGet(port, "/unknown");
+    assert.equal(res.status, 404);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Async background job mode (requires cron engine)
+// ---------------------------------------------------------------------------
+
+describe("async background job mode", () => {
+  const log = createLogger("silent");
+  let server;
+  let port;
+  let tmpDir;
+  const state = { agentName: "test" };
+
+  before(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "resp-async-"));
+    mkdirSync(join(tmpDir, "data", "test", "bg-jobs"), { recursive: true });
+    server = createChatApiServer(log, tmpDir, state);
+    port = await server.start(0);
+    server.bindSession({
+      sendAndWait: async () => ({ data: { content: "async response" } }),
+      send: async () => {},
+      getMessages: async () => [],
+      onEvent: () => () => {},
+    });
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns 503 when cron engine is not running (default async)", async () => {
+    const res = await httpPost(port, "/v1/responses", { input: "hello" });
+    assert.equal(res.status, 503);
+    assert.ok(res.body.error.message.includes("Cron engine"));
+  });
+
+  it("returns 503 on explicit async: true without cron engine", async () => {
+    const res = await httpPost(port, "/v1/responses", { input: "hello", async: true });
+    assert.equal(res.status, 503);
+  });
+
+  it("returns 200 on async: false (sync mode bypass)", async () => {
+    const res = await httpPost(port, "/v1/responses", { input: "sync", async: false });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.status, "completed");
+  });
+
+  it("returns 400 on async request with missing input", async () => {
+    const res = await httpPost(port, "/v1/responses", { async: true });
+    assert.equal(res.status, 400);
+  });
+});

--- a/.github/extensions/responses/lib/logger.mjs
+++ b/.github/extensions/responses/lib/logger.mjs
@@ -1,0 +1,16 @@
+const LEVELS = { silent: 0, error: 1, info: 2, debug: 3 };
+const VALID_LEVELS = new Set(Object.keys(LEVELS));
+
+const noop = () => {};
+
+export function createLogger(logLevel = "info") {
+  const level = VALID_LEVELS.has(logLevel) ? logLevel : "info";
+  const threshold = LEVELS[level];
+
+  return {
+    error: threshold >= LEVELS.error ? (...args) => console.error("responses:", ...args) : noop,
+    info:  threshold >= LEVELS.info  ? (...args) => console.error("responses:", ...args) : noop,
+    debug: threshold >= LEVELS.debug ? (...args) => console.error("responses:", ...args) : noop,
+    level,
+  };
+}

--- a/.github/extensions/responses/lib/paths.mjs
+++ b/.github/extensions/responses/lib/paths.mjs
@@ -1,0 +1,29 @@
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+export function getExtensionDir() {
+  return join(dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+/**
+ * Validate and sanitize an agent name.
+ * Only [a-zA-Z0-9_-] characters are kept (filesystem safety).
+ * Returns null if the input is empty or entirely invalid.
+ */
+export function sanitizeAgentName(raw) {
+  if (!raw || typeof raw !== "string") return null;
+  const sanitized = raw.trim().replace(/[^a-zA-Z0-9_-]/g, "");
+  return sanitized.length > 0 ? sanitized : null;
+}
+
+export function getDataDir(extDir, agentName) {
+  return join(extDir, "data", agentName);
+}
+
+export function getLockfilePath(extDir, agentName) {
+  return join(extDir, "data", agentName, "responses.lock");
+}
+
+export function getConfigPath(extDir, agentName) {
+  return join(extDir, "data", agentName, "config.json");
+}

--- a/.github/extensions/responses/lib/progress-reader.mjs
+++ b/.github/extensions/responses/lib/progress-reader.mjs
@@ -1,0 +1,39 @@
+// Reads JSONL progress files and returns status items for the RSS feed / job detail.
+
+import { readFileSync, existsSync } from "node:fs";
+
+/**
+ * Read a progress JSONL file and return an array of status items.
+ * Returns [] if the file doesn't exist, is empty, or is entirely malformed.
+ * Skips individual malformed lines (handles partial writes during active execution).
+ *
+ * @param {string} filePath - Absolute path to the .progress.jsonl file
+ * @returns {Array<{ title: string, description: string, timestamp: string, fullText?: string }>}
+ */
+export function readProgressEvents(filePath) {
+  try {
+    if (!filePath || !existsSync(filePath)) return [];
+
+    const content = readFileSync(filePath, "utf-8");
+    if (!content.trim()) return [];
+
+    const items = [];
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const event = JSON.parse(line);
+        items.push({
+          title: event.title || "Progress",
+          description: event.description || "",
+          timestamp: event.timestamp || "",
+          ...(event.fullText ? { fullText: event.fullText } : {}),
+        });
+      } catch {
+        // Skip malformed lines (e.g. partial write at end of file)
+      }
+    }
+    return items;
+  } catch {
+    return [];
+  }
+}

--- a/.github/extensions/responses/lib/progress-reader.test.mjs
+++ b/.github/extensions/responses/lib/progress-reader.test.mjs
@@ -1,0 +1,123 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { readProgressEvents } from "./progress-reader.mjs";
+
+describe("readProgressEvents", () => {
+  let tmpDir;
+  before(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "pr-test-"));
+  });
+  after(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty array for missing file", () => {
+    assert.deepEqual(readProgressEvents(join(tmpDir, "nope.jsonl")), []);
+  });
+
+  it("returns empty array for null/undefined path", () => {
+    assert.deepEqual(readProgressEvents(null), []);
+    assert.deepEqual(readProgressEvents(undefined), []);
+    assert.deepEqual(readProgressEvents(""), []);
+  });
+
+  it("returns empty array for empty file", () => {
+    const p = join(tmpDir, "empty.jsonl");
+    writeFileSync(p, "", "utf-8");
+    assert.deepEqual(readProgressEvents(p), []);
+  });
+
+  it("parses a single event line", () => {
+    const p = join(tmpDir, "single.jsonl");
+    writeFileSync(p, JSON.stringify({
+      type: "tool_start",
+      title: "Tool: grep",
+      description: "searching src/",
+      timestamp: "2025-01-15T12:00:00Z",
+    }) + "\n", "utf-8");
+
+    const items = readProgressEvents(p);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, "Tool: grep");
+    assert.equal(items[0].description, "searching src/");
+    assert.equal(items[0].timestamp, "2025-01-15T12:00:00Z");
+  });
+
+  it("parses multiple event lines", () => {
+    const p = join(tmpDir, "multi.jsonl");
+    const lines = [
+      { type: "tool_start", title: "Tool: grep", description: "a", timestamp: "2025-01-15T12:00:01Z" },
+      { type: "tool_complete", title: "✓ grep", description: "b", timestamp: "2025-01-15T12:00:02Z" },
+      { type: "turn_end", title: "Agent turn completed", description: "", timestamp: "2025-01-15T12:00:03Z" },
+    ];
+    writeFileSync(p, lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf-8");
+
+    const items = readProgressEvents(p);
+    assert.equal(items.length, 3);
+    assert.equal(items[0].title, "Tool: grep");
+    assert.equal(items[2].title, "Agent turn completed");
+  });
+
+  it("skips malformed lines gracefully", () => {
+    const p = join(tmpDir, "malformed.jsonl");
+    const content = [
+      JSON.stringify({ type: "a", title: "good", timestamp: "2025-01-15T12:00:00Z" }),
+      "this is not json",
+      JSON.stringify({ type: "b", title: "also good", timestamp: "2025-01-15T12:00:01Z" }),
+      "{incomplete json",
+    ].join("\n") + "\n";
+    writeFileSync(p, content, "utf-8");
+
+    const items = readProgressEvents(p);
+    assert.equal(items.length, 2);
+    assert.equal(items[0].title, "good");
+    assert.equal(items[1].title, "also good");
+  });
+
+  it("skips blank lines", () => {
+    const p = join(tmpDir, "blanks.jsonl");
+    const content = "\n" + JSON.stringify({ type: "a", title: "test", timestamp: "t" }) + "\n\n\n";
+    writeFileSync(p, content, "utf-8");
+
+    const items = readProgressEvents(p);
+    assert.equal(items.length, 1);
+  });
+
+  it("defaults missing title to 'Progress'", () => {
+    const p = join(tmpDir, "no-title.jsonl");
+    writeFileSync(p, JSON.stringify({ type: "x", timestamp: "t" }) + "\n", "utf-8");
+
+    const items = readProgressEvents(p);
+    assert.equal(items[0].title, "Progress");
+  });
+
+  it("includes fullText when present in event", () => {
+    const p = join(tmpDir, "fulltext.jsonl");
+    writeFileSync(p, JSON.stringify({
+      type: "tool_complete",
+      title: "✓ grep",
+      description: "short",
+      timestamp: "t",
+      fullText: "very long detailed output here",
+    }) + "\n", "utf-8");
+
+    const items = readProgressEvents(p);
+    assert.equal(items[0].fullText, "very long detailed output here");
+  });
+
+  it("omits fullText key when not in event", () => {
+    const p = join(tmpDir, "no-fulltext.jsonl");
+    writeFileSync(p, JSON.stringify({
+      type: "tool_start",
+      title: "Tool: edit",
+      timestamp: "t",
+    }) + "\n", "utf-8");
+
+    const items = readProgressEvents(p);
+    assert.ok(!("fullText" in items[0]));
+  });
+});

--- a/.github/extensions/responses/lib/responses.mjs
+++ b/.github/extensions/responses/lib/responses.mjs
@@ -1,0 +1,290 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Translates between OpenAI Responses API format and the Copilot session.
+ *
+ * Supports:
+ *   - POST /v1/responses  (non-streaming + streaming)
+ *   - Normalizes input (string or conversation array) to a prompt string
+ *   - Wraps agent output in the OpenAI response envelope
+ *   - Emits proper SSE event sequence for streaming
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function responseId() {
+  return `resp_${randomUUID().replace(/-/g, "")}`;
+}
+
+function messageId() {
+  return `msg_${randomUUID().replace(/-/g, "")}`;
+}
+
+function nowUnix() {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Normalize the `input` field into a plain prompt string.
+ * Accepts:
+ *   - string
+ *   - array of { role, content } conversation items (takes the last user message)
+ */
+export function normalizeInput(input, instructions) {
+  let prompt = "";
+
+  if (typeof input === "string") {
+    prompt = input;
+  } else if (Array.isArray(input)) {
+    // Collect user messages; use the last one as the prompt
+    const parts = [];
+    for (const item of input) {
+      if (typeof item === "string") {
+        parts.push(item);
+      } else if (item.content) {
+        const text =
+          typeof item.content === "string"
+            ? item.content
+            : Array.isArray(item.content)
+              ? item.content
+                  .filter((c) => c.type === "input_text" || c.type === "text")
+                  .map((c) => c.text)
+                  .join("\n")
+              : String(item.content);
+        parts.push(text);
+      }
+    }
+    prompt = parts.join("\n\n");
+  }
+
+  // Prepend instructions if provided
+  if (instructions && typeof instructions === "string") {
+    prompt = `[System instructions: ${instructions}]\n\n${prompt}`;
+  }
+
+  return prompt;
+}
+
+// ---------------------------------------------------------------------------
+// Background job 202 response
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a 202 Accepted envelope for background job requests.
+ */
+export function build202Response(jobId, feedUrl) {
+  return {
+    id: jobId,
+    object: "response",
+    created_at: nowUnix(),
+    status: "queued",
+    feed_url: feedUrl,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Non-streaming response builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a complete OpenAI Responses API response object.
+ */
+export function buildResponse(content, opts = {}) {
+  const id = opts.id || responseId();
+  const model = opts.model || "copilot-agent";
+
+  return {
+    id,
+    object: "response",
+    created_at: nowUnix(),
+    status: "completed",
+    model,
+    output: [
+      {
+        type: "message",
+        id: messageId(),
+        status: "completed",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: content,
+          },
+        ],
+      },
+    ],
+    output_text: content,
+    parallel_tool_calls: false,
+    previous_response_id: opts.previousResponseId || null,
+    reasoning: null,
+    store: false,
+    temperature: opts.temperature ?? 1.0,
+    text: { format: { type: "text" } },
+    tool_choice: "auto",
+    tools: [],
+    top_p: 1.0,
+    usage: null,
+    metadata: opts.metadata || {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Streaming helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a single SSE event to the response stream.
+ */
+function sseEvent(res, eventType, data) {
+  res.write(`event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+/**
+ * Create a streaming handler that emits OpenAI Responses API SSE events.
+ *
+ * Event sequence:
+ *   1. response.created
+ *   2. response.output_item.added
+ *   3. response.content_part.added
+ *   4. response.output_text.delta  (repeated)
+ *   5. response.content_part.done
+ *   6. response.output_item.done
+ *   7. response.completed
+ */
+export function createStreamWriter(res, opts = {}) {
+  const id = opts.id || responseId();
+  const msgId = messageId();
+  const model = opts.model || "copilot-agent";
+  const createdAt = nowUnix();
+  let accumulatedText = "";
+  let sequenceNumber = 0;
+
+  // Write SSE headers
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  });
+
+  const baseResponse = {
+    id,
+    object: "response",
+    created_at: createdAt,
+    status: "in_progress",
+    model,
+    output: [],
+    output_text: "",
+    parallel_tool_calls: false,
+    previous_response_id: opts.previousResponseId || null,
+    reasoning: null,
+    store: false,
+    temperature: opts.temperature ?? 1.0,
+    text: { format: { type: "text" } },
+    tool_choice: "auto",
+    tools: [],
+    top_p: 1.0,
+    usage: null,
+    metadata: opts.metadata || {},
+  };
+
+  // 1. response.created
+  sseEvent(res, "response.created", baseResponse);
+
+  // 2. response.output_item.added
+  const outputItem = {
+    type: "message",
+    id: msgId,
+    status: "in_progress",
+    role: "assistant",
+    content: [],
+  };
+  sseEvent(res, "response.output_item.added", {
+    output_index: 0,
+    item: outputItem,
+    sequence_number: sequenceNumber++,
+  });
+
+  // 3. response.content_part.added
+  const contentPart = { type: "output_text", text: "" };
+  sseEvent(res, "response.content_part.added", {
+    output_index: 0,
+    content_index: 0,
+    part: contentPart,
+    sequence_number: sequenceNumber++,
+  });
+
+  return {
+    /** Emit a text delta chunk. */
+    writeDelta(text) {
+      if (!text) return;
+      accumulatedText += text;
+      sseEvent(res, "response.output_text.delta", {
+        output_index: 0,
+        content_index: 0,
+        delta: text,
+        sequence_number: sequenceNumber++,
+      });
+    },
+
+    /** Finalize the stream with a completed response. */
+    complete() {
+      // content_part.done
+      sseEvent(res, "response.content_part.done", {
+        output_index: 0,
+        content_index: 0,
+        part: { type: "output_text", text: accumulatedText },
+        sequence_number: sequenceNumber++,
+      });
+
+      // output_item.done
+      sseEvent(res, "response.output_item.done", {
+        output_index: 0,
+        item: {
+          type: "message",
+          id: msgId,
+          status: "completed",
+          role: "assistant",
+          content: [{ type: "output_text", text: accumulatedText }],
+        },
+        sequence_number: sequenceNumber++,
+      });
+
+      // response.completed
+      sseEvent(res, "response.completed", {
+        ...baseResponse,
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            id: msgId,
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "output_text", text: accumulatedText }],
+          },
+        ],
+        output_text: accumulatedText,
+      });
+
+      res.end();
+    },
+
+    /** Emit an error and close the stream. */
+    error(message) {
+      sseEvent(res, "error", {
+        type: "server_error",
+        message,
+      });
+      res.end();
+    },
+
+    /** Get accumulated text so far. */
+    getText() {
+      return accumulatedText;
+    },
+  };
+}

--- a/.github/extensions/responses/lib/responses.test.mjs
+++ b/.github/extensions/responses/lib/responses.test.mjs
@@ -1,0 +1,219 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeInput,
+  buildResponse,
+  build202Response,
+  createStreamWriter,
+} from "./responses.mjs";
+
+// ---------------------------------------------------------------------------
+// Mock response object for streaming tests
+// ---------------------------------------------------------------------------
+
+function createMockRes() {
+  const written = [];
+  const headers = {};
+  return {
+    writeHead(status, hdrs) {
+      Object.assign(headers, { status, ...hdrs });
+    },
+    write(chunk) {
+      written.push(chunk);
+    },
+    end() {
+      written.push("__END__");
+    },
+    written,
+    headers,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// normalizeInput
+// ---------------------------------------------------------------------------
+
+describe("normalizeInput", () => {
+  it("passes through a plain string", () => {
+    assert.equal(normalizeInput("hello"), "hello");
+  });
+
+  it("joins array of strings with double newline", () => {
+    assert.equal(normalizeInput(["a", "b", "c"]), "a\n\nb\n\nc");
+  });
+
+  it("extracts content from conversation array [{role, content}]", () => {
+    const input = [
+      { role: "user", content: "first" },
+      { role: "assistant", content: "second" },
+    ];
+    assert.equal(normalizeInput(input), "first\n\nsecond");
+  });
+
+  it('handles nested content arrays with type: "input_text"', () => {
+    const input = [
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "nested input" }],
+      },
+    ];
+    assert.equal(normalizeInput(input), "nested input");
+  });
+
+  it('handles nested content arrays with type: "text"', () => {
+    const input = [
+      {
+        role: "user",
+        content: [{ type: "text", text: "nested text" }],
+      },
+    ];
+    assert.equal(normalizeInput(input), "nested text");
+  });
+
+  it("prepends instructions when provided", () => {
+    const result = normalizeInput("prompt", "do this");
+    assert.equal(result, "[System instructions: do this]\n\nprompt");
+  });
+
+  it("handles null/undefined instructions (no prepend)", () => {
+    assert.equal(normalizeInput("prompt", null), "prompt");
+    assert.equal(normalizeInput("prompt", undefined), "prompt");
+  });
+
+  it("handles empty array → empty string", () => {
+    assert.equal(normalizeInput([]), "");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildResponse
+// ---------------------------------------------------------------------------
+
+describe("buildResponse", () => {
+  it("returns object with correct shape", () => {
+    const r = buildResponse("hello");
+    assert.ok(r.id);
+    assert.equal(r.object, "response");
+    assert.equal(typeof r.created_at, "number");
+    assert.ok(Array.isArray(r.output));
+    assert.equal(typeof r.output_text, "string");
+  });
+
+  it('status is "completed"', () => {
+    assert.equal(buildResponse("x").status, "completed");
+  });
+
+  it("output_text matches input content", () => {
+    assert.equal(buildResponse("hello world").output_text, "hello world");
+  });
+
+  it("uses provided model name", () => {
+    const r = buildResponse("x", { model: "gpt-5" });
+    assert.equal(r.model, "gpt-5");
+  });
+
+  it('generates unique id starting with "resp_"', () => {
+    const a = buildResponse("x");
+    const b = buildResponse("x");
+    assert.ok(a.id.startsWith("resp_"));
+    assert.ok(b.id.startsWith("resp_"));
+    assert.notEqual(a.id, b.id);
+  });
+
+  it("includes previousResponseId from opts", () => {
+    const r = buildResponse("x", { previousResponseId: "prev_123" });
+    assert.equal(r.previous_response_id, "prev_123");
+  });
+
+  it("includes metadata from opts", () => {
+    const meta = { foo: "bar" };
+    const r = buildResponse("x", { metadata: meta });
+    assert.deepEqual(r.metadata, meta);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// build202Response
+// ---------------------------------------------------------------------------
+
+describe("build202Response", () => {
+  it("returns object with jobId as id", () => {
+    const r = build202Response("job_abc", "https://feed");
+    assert.equal(r.id, "job_abc");
+  });
+
+  it('status is "queued"', () => {
+    const r = build202Response("job_abc", "https://feed");
+    assert.equal(r.status, "queued");
+  });
+
+  it("includes feed_url", () => {
+    const r = build202Response("job_abc", "https://feed/url");
+    assert.equal(r.feed_url, "https://feed/url");
+  });
+
+  it("has created_at as unix timestamp", () => {
+    const before = Math.floor(Date.now() / 1000);
+    const r = build202Response("j", "f");
+    const after = Math.floor(Date.now() / 1000);
+    assert.ok(r.created_at >= before && r.created_at <= after);
+  });
+
+  it('object is "response"', () => {
+    assert.equal(build202Response("j", "f").object, "response");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createStreamWriter
+// ---------------------------------------------------------------------------
+
+describe("createStreamWriter", () => {
+  it("writes SSE headers to response", () => {
+    const mock = createMockRes();
+    createStreamWriter(mock);
+    assert.equal(mock.headers.status, 200);
+    assert.equal(mock.headers["Content-Type"], "text/event-stream");
+    assert.equal(mock.headers["Cache-Control"], "no-cache");
+  });
+
+  it("writeDelta accumulates text", () => {
+    const mock = createMockRes();
+    const sw = createStreamWriter(mock);
+    sw.writeDelta("hello ");
+    sw.writeDelta("world");
+    assert.equal(sw.getText(), "hello world");
+  });
+
+  it("getText returns accumulated text", () => {
+    const mock = createMockRes();
+    const sw = createStreamWriter(mock);
+    assert.equal(sw.getText(), "");
+    sw.writeDelta("abc");
+    assert.equal(sw.getText(), "abc");
+  });
+
+  it("complete writes final events", () => {
+    const mock = createMockRes();
+    const sw = createStreamWriter(mock);
+    sw.writeDelta("done");
+    sw.complete();
+
+    const all = mock.written.join("");
+    assert.ok(all.includes("event: response.content_part.done"));
+    assert.ok(all.includes("event: response.output_item.done"));
+    assert.ok(all.includes("event: response.completed"));
+    assert.equal(mock.written.at(-1), "__END__");
+  });
+
+  it("error writes error event", () => {
+    const mock = createMockRes();
+    const sw = createStreamWriter(mock);
+    sw.error("something broke");
+
+    const all = mock.written.join("");
+    assert.ok(all.includes("event: error"));
+    assert.ok(all.includes("something broke"));
+    assert.equal(mock.written.at(-1), "__END__");
+  });
+});

--- a/.github/extensions/responses/lib/rss-builder.mjs
+++ b/.github/extensions/responses/lib/rss-builder.mjs
@@ -1,0 +1,56 @@
+// RSS 2.0 feed builder for job status data.
+// Adapted from jplane/copilot-cli-extensions (Josh's rss-feed extension).
+
+function escapeXml(str) {
+  if (str == null) return "";
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function toRfc822(dateStr) {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return "";
+  return d.toUTCString();
+}
+
+function truncateDesc(text, max = 200) {
+  if (!text) return "";
+  return text.length > max ? text.slice(0, max) + "…" : text;
+}
+
+export function buildRssFeed(job, statusItems, port) {
+  const jobId = escapeXml(job.id);
+  const link = `http://127.0.0.1:${port}/jobs/${jobId}`;
+  const prompt = escapeXml((job.prompt || "").slice(0, 200));
+  const lastBuild = toRfc822(job.updatedAt || job.createdAt);
+
+  const items = (statusItems || []).map(item => {
+    const contentEncoded = item.fullText
+      ? `\n      <content:encoded><![CDATA[${item.fullText}]]></content:encoded>`
+      : "";
+    return `
+    <item>
+      <title>${escapeXml(item.title)}</title>
+      <description>${escapeXml(truncateDesc(item.description))}</description>${contentEncoded}
+      <link>${link}</link>
+      <pubDate>${toRfc822(item.timestamp)}</pubDate>
+      <guid isPermaLink="false">${jobId}-${escapeXml(item.timestamp)}</guid>
+    </item>`;
+  }).join("");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>Job ${jobId} — Status Feed</title>
+    <link>${link}</link>
+    <description>Status updates for job: ${prompt}</description>
+    <language>en-us</language>
+    <lastBuildDate>${lastBuild}</lastBuildDate>${items}
+  </channel>
+</rss>`;
+}

--- a/.github/extensions/responses/lib/rss-builder.test.mjs
+++ b/.github/extensions/responses/lib/rss-builder.test.mjs
@@ -1,0 +1,134 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildRssFeed } from "./rss-builder.mjs";
+
+function makeJob(overrides = {}) {
+  return {
+    id: "job-001",
+    prompt: "Summarize the latest news",
+    createdAt: "2025-01-15T10:00:00Z",
+    updatedAt: "2025-01-15T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeItems(count = 1) {
+  return Array.from({ length: count }, (_, i) => ({
+    title: `Status ${i + 1}`,
+    description: `Description for status ${i + 1}`,
+    timestamp: `2025-01-15T1${i}:00:00Z`,
+  }));
+}
+
+describe("buildRssFeed", () => {
+  it("generates valid XML with correct structure", () => {
+    const xml = buildRssFeed(makeJob(), makeItems(), 3000);
+
+    assert.ok(xml.startsWith("<?xml"), "should start with <?xml");
+    assert.ok(xml.includes('<rss version="2.0"'), "should contain <rss version=\"2.0\"");
+    assert.ok(xml.includes("xmlns:content"), "should contain content namespace");
+    assert.ok(xml.includes("<channel>"), "should contain <channel>");
+    assert.ok(xml.includes("Job job-001"), "should contain the job ID in the title");
+    assert.ok(xml.includes("http://127.0.0.1:3000/jobs/job-001"), "should contain the port in the link URL");
+  });
+
+  it("escapes XML special characters in prompt", () => {
+    const job = makeJob({ prompt: '<script>alert("x")&\'test\'' });
+    const xml = buildRssFeed(job, [], 3000);
+
+    assert.ok(xml.includes("&lt;script&gt;"), "should escape < and >");
+    assert.ok(xml.includes("&amp;"), "should escape &");
+    assert.ok(xml.includes("&quot;"), "should escape double quotes");
+    assert.ok(xml.includes("&apos;"), "should escape single quotes");
+    assert.ok(!xml.includes('<script>'), "should not contain raw <script>");
+  });
+
+  it("handles empty statusItems array", () => {
+    const xml = buildRssFeed(makeJob(), [], 3000);
+
+    assert.ok(xml.includes("<?xml"), "should still be valid XML");
+    assert.ok(!xml.includes("<item>"), "should not contain <item> elements");
+  });
+
+  it("creates one <item> per statusItem", () => {
+    const xml = buildRssFeed(makeJob(), makeItems(3), 3000);
+    const itemCount = (xml.match(/<item>/g) || []).length;
+
+    assert.equal(itemCount, 3, "should have exactly 3 <item> blocks");
+  });
+
+  it("includes pubDate in RFC 822 format", () => {
+    const items = [{ title: "T", description: "D", timestamp: "2025-06-20T14:30:00Z" }];
+    const xml = buildRssFeed(makeJob(), items, 3000);
+    const expected = new Date("2025-06-20T14:30:00Z").toUTCString();
+
+    assert.ok(xml.includes(`<pubDate>${expected}</pubDate>`), "should include RFC 822 pubDate");
+  });
+
+  it("includes guid with job ID and timestamp", () => {
+    const xml = buildRssFeed(makeJob(), makeItems(1), 3000);
+
+    assert.ok(xml.includes('<guid isPermaLink="false">'), "should contain guid element");
+    assert.ok(xml.includes("job-001-"), "guid should contain job ID");
+  });
+
+  it("truncates long prompts to 200 chars", () => {
+    const longPrompt = "A".repeat(500);
+    const job = makeJob({ prompt: longPrompt });
+    const xml = buildRssFeed(job, [], 3000);
+
+    assert.ok(!xml.includes("A".repeat(201)), "should not contain more than 200 chars of prompt");
+    assert.ok(xml.includes("A".repeat(200)), "should contain exactly 200 chars of prompt");
+  });
+
+  it("handles missing/null fields gracefully", () => {
+    const job = { id: "job-null", prompt: null, createdAt: null, updatedAt: null };
+
+    assert.doesNotThrow(() => buildRssFeed(job, [], 3000));
+
+    const xml = buildRssFeed(job, [], 3000);
+    assert.ok(xml.includes("<?xml"), "should produce valid XML");
+    assert.ok(xml.includes("<channel>"), "should still have channel");
+  });
+
+  it("uses createdAt when updatedAt is null for lastBuildDate", () => {
+    const job = makeJob({ updatedAt: null });
+    const xml = buildRssFeed(job, [], 3000);
+    const expected = new Date("2025-01-15T10:00:00Z").toUTCString();
+
+    assert.ok(xml.includes(`<lastBuildDate>${expected}</lastBuildDate>`), "should fall back to createdAt");
+  });
+
+  it("includes content:encoded CDATA when item has fullText", () => {
+    const items = [{
+      title: "Response",
+      description: "Full AI response with lots of detail.",
+      timestamp: "2025-01-15T11:00:00Z",
+      fullText: "Full AI response with lots of detail.",
+    }];
+    const xml = buildRssFeed(makeJob(), items, 3000);
+
+    assert.ok(xml.includes("<content:encoded>"), "should contain content:encoded element");
+    assert.ok(xml.includes("<![CDATA[Full AI response"), "should wrap fullText in CDATA");
+    assert.ok(xml.includes("]]></content:encoded>"), "should close CDATA and element");
+  });
+
+  it("omits content:encoded when item has no fullText", () => {
+    const xml = buildRssFeed(makeJob(), makeItems(1), 3000);
+
+    assert.ok(!xml.includes("content:encoded"), "should not contain content:encoded");
+    assert.ok(!xml.includes("<![CDATA["), "should not contain CDATA");
+  });
+
+  it("truncates long descriptions with ellipsis", () => {
+    const items = [{
+      title: "Response",
+      description: "A".repeat(300),
+      timestamp: "2025-01-15T11:00:00Z",
+    }];
+    const xml = buildRssFeed(makeJob(), items, 3000);
+
+    assert.ok(!xml.includes("A".repeat(201)), "description should be truncated");
+    assert.ok(xml.includes("…"), "should contain ellipsis");
+  });
+});

--- a/.github/extensions/responses/lib/server.mjs
+++ b/.github/extensions/responses/lib/server.mjs
@@ -1,0 +1,708 @@
+import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
+import { resolve as pathResolve, join } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { createRequire } from "node:module";
+import {
+  normalizeInput,
+  build202Response,
+  createStreamWriter,
+} from "./responses.mjs";
+import { createJob, getJob, listJobs, updateJobStatus, removeJob, removeProgressFile, getBgJobsDir } from "./job-registry.mjs";
+import { isCronEngineRunning, createOneShotCronJob, findRunningEngines } from "./cron-bridge.mjs";
+import { resolveJobStatus } from "./job-status.mjs";
+import { buildRssFeed } from "./rss-builder.mjs";
+// Session RSS (#49) — reads SDK's native events.jsonl
+import { readEvents, readSession } from "./events-reader.mjs";
+import { buildSessionRSS } from "./session-rss.mjs";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Creates an HTTP server that bridges external clients to the Copilot session
+ * via an OpenAI Responses API–compatible interface.
+ *
+ * Endpoints:
+ *   POST   /v1/responses  — OpenAI Responses API (async-default, 202 + RSS)
+ *   GET    /jobs           — list background jobs with RSS feed URLs
+ *   GET    /jobs/:id       — single job detail with status items
+ *   GET    /feed/:jobId    — RSS 2.0 XML feed for job progress
+ *   DELETE /jobs/:id       — cancel a background job
+ *   GET    /health         — liveness check
+ *   GET    /history        — recent conversation history
+ *
+ * Session methods are bound once via bindSession() after joinSession() resolves.
+ * The server only exists while a session is active (process = lifecycle unit).
+ */
+export function createChatApiServer(log, extDir, state) {
+  let server = null;
+  let port = null;
+  let session = null;
+  const sseClients = [];
+
+  function corsHeaders() {
+    return {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    };
+  }
+
+  function jsonResponse(res, status, body) {
+    const payload = JSON.stringify(body);
+    res.writeHead(status, {
+      ...corsHeaders(),
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(payload),
+    });
+    res.end(payload);
+  }
+
+  function xmlResponse(res, status, xml) {
+    res.writeHead(status, {
+      ...corsHeaders(),
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Content-Length": Buffer.byteLength(xml),
+    });
+    res.end(xml);
+  }
+
+  function readBody(req) {
+    return new Promise((resolve, reject) => {
+      const chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString()));
+        } catch {
+          reject(new Error("invalid json"));
+        }
+      });
+      req.on("error", reject);
+    });
+  }
+
+  function feedUrl(jobId) {
+    return `http://127.0.0.1:${port}/feed/${jobId}`;
+  }
+
+  function sessionUrl(sessionId) {
+    return `http://127.0.0.1:${port}/sessions/${encodeURIComponent(sessionId)}`;
+  }
+
+  /**
+   * Build an XML message envelope wrapping the prompt. The receiving agent sees
+   * structured metadata (who sent it, how it arrived) and the actual message
+   * content in clean, parseable sections.
+   */
+  function buildEnvelope(mode, prompt, opts = {}) {
+    const fromAttr = opts.from ? ` from="${opts.from}"` : "";
+    const lines = [`<message${fromAttr}>`];
+
+    if (opts.from) {
+      lines.push(`  <from agent="${opts.from}">`);
+      lines.push(`    Check your Yellow Pages (contacts.json) for context on this agent.`);
+      lines.push(`  </from>`);
+    }
+
+    if (mode === "fire-and-forget") {
+      lines.push(`  <delivery mode="fire-and-forget">`);
+      lines.push(`    The caller is not waiting for a response. Use your judgment —`);
+      lines.push(`    the content determines whether action or a reply is appropriate.`);
+      lines.push(`    To reply, use your Yellow Pages to reach the sender.`);
+      lines.push(`  </delivery>`);
+    } else if (mode === "streaming") {
+      lines.push(`  <delivery mode="streaming">`);
+      lines.push(`    The caller is connected via SSE and receiving your output in`);
+      lines.push(`    real time. Respond normally.`);
+      lines.push(`  </delivery>`);
+    } else if (mode === "background") {
+      const attrs = [];
+      if (opts.jobId) attrs.push(`job-id="${opts.jobId}"`);
+      if (opts.feedUrl) attrs.push(`feed-url="${opts.feedUrl}"`);
+      const attrStr = attrs.length ? " " + attrs.join(" ") : "";
+      lines.push(`  <delivery mode="background"${attrStr}>`);
+      lines.push(`    This is a tracked background job. Your work and response are`);
+      lines.push(`    captured in the feed. Complete the task described in the content.`);
+      lines.push(`  </delivery>`);
+    }
+
+    lines.push(`  <content>`);
+    lines.push(prompt);
+    lines.push(`  </content>`);
+    lines.push(`</message>`);
+
+    return lines.join("\n");
+  }
+
+  /** Query session-store.db synchronously. Returns [] on any error. */
+  function querySessionStore(sql, params = []) {
+    try {
+      const dbPath = join(homedir(), ".copilot", "session-store.db");
+      const Database = require("better-sqlite3");
+      const db = new Database(dbPath, { readonly: true });
+      const rows = db.prepare(sql).all(...params);
+      db.close();
+      return rows;
+    } catch (e) {
+      log.debug(`session-store query failed: ${e.message}`);
+      return [];
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /history
+  // ---------------------------------------------------------------------------
+
+  async function handleHistory(req, res) {
+    try {
+      const url = new URL(req.url, `http://${req.headers.host}`);
+      const limit = parseInt(url.searchParams.get("limit"), 10) || 0;
+      let messages = await session.getMessages();
+      if (limit > 0) {
+        messages = messages.slice(-limit);
+      }
+      jsonResponse(res, 200, { messages });
+    } catch (err) {
+      jsonResponse(res, 500, { error: err.message });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /health
+  // ---------------------------------------------------------------------------
+
+  function handleHealth(_req, res) {
+    const agentName = state.agentName;
+    let jobCount = 0;
+    if (agentName) {
+      try { jobCount = listJobs(extDir, agentName).length; } catch { /* best effort */ }
+    }
+    jsonResponse(res, 200, {
+      status: "ok",
+      session: "connected",
+      port,
+      jobs: jobCount,
+      uptime: process.uptime(),
+      timestamp: Date.now(),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /v1/responses — async-default with background jobs
+  // ---------------------------------------------------------------------------
+
+  async function handleResponses(req, res) {
+    let body;
+    try {
+      body = await readBody(req);
+    } catch {
+      return jsonResponse(res, 400, {
+        error: { type: "invalid_request_error", message: "Invalid JSON body" },
+      });
+    }
+
+    const input = body.input;
+    if (input === undefined || input === null) {
+      return jsonResponse(res, 400, {
+        error: {
+          type: "invalid_request_error",
+          message: "Missing required field: input",
+        },
+      });
+    }
+
+    const prompt = normalizeInput(input, body.instructions);
+    const fromAgent = req.headers["x-agent-name"] || null;
+    const opts = {
+      model: body.model,
+      previousResponseId: body.previous_response_id,
+      temperature: body.temperature,
+      metadata: body.metadata,
+    };
+
+    const timeout = typeof body.timeout === "number" ? body.timeout : 120_000;
+
+    // --- Streaming (explicit opt-in) ---
+    if (body.stream === true) {
+      const writer = createStreamWriter(res, opts);
+      const unsubs = [];
+
+      const offDelta = session.onEvent("assistant.streaming_delta", (event) => {
+        const chunk = event?.data?.content || event?.data?.delta || "";
+        if (chunk) writer.writeDelta(chunk);
+      });
+      unsubs.push(offDelta);
+
+      let finalContent = "";
+      const done = new Promise((resolve) => {
+        const offMessage = session.onEvent("assistant.message", (event) => {
+          finalContent = event?.data?.content ?? "";
+          resolve();
+        });
+        unsubs.push(offMessage);
+      });
+
+      try {
+        await session.send({ prompt: buildEnvelope("streaming", prompt, { from: fromAgent }) });
+      } catch (err) {
+        unsubs.forEach((fn) => fn());
+        return writer.error(err.message);
+      }
+
+      const timeout = setTimeout(() => {
+        unsubs.forEach((fn) => fn());
+        writer.error("Request timed out");
+      }, 300_000);
+
+      req.on("close", () => {
+        clearTimeout(timeout);
+        unsubs.forEach((fn) => fn());
+      });
+
+      await done;
+      clearTimeout(timeout);
+      unsubs.forEach((fn) => fn());
+
+      if (!writer.getText() && finalContent) {
+        writer.writeDelta(finalContent);
+      }
+
+      writer.complete();
+      return;
+    }
+
+    // --- Fire-and-forget on current session (async: false) ---
+    if (body.async === false) {
+      try {
+        await session.send({ prompt: buildEnvelope("fire-and-forget", prompt, { from: fromAgent }) });
+        jsonResponse(res, 202, {
+          object: "response",
+          created_at: Math.floor(Date.now() / 1000),
+          status: "accepted",
+          message: "Prompt sent to current session",
+        });
+      } catch (err) {
+        jsonResponse(res, 502, {
+          error: {
+            type: "server_error",
+            message: "Failed to send prompt to session",
+            detail: err.message,
+          },
+        });
+      }
+      return;
+    }
+
+    // --- Async / Background job (default) ---
+    const agentName = state.agentName;
+    if (!agentName) {
+      return jsonResponse(res, 503, {
+        error: {
+          type: "server_error",
+          message: "No agent namespace configured. Call responses_restart first.",
+        },
+      });
+    }
+
+    const engine = isCronEngineRunning(extDir, agentName);
+    if (!engine.running) {
+      const others = findRunningEngines(extDir);
+      if (others.length > 0) {
+        const names = others.map((e) => `"${e.agentName}"`).join(", ");
+        return jsonResponse(res, 409, {
+          error: {
+            type: "configuration_error",
+            message: `No cron engine running for agent "${agentName}", but found engine(s) running as: ${names}. `
+              + `Call responses_restart(agent: ${others.length === 1 ? others[0].agentName : "NAME"}) to align, `
+              + `or set COPILOT_AGENT="${agentName}" and restart the cron engine.`,
+          },
+        });
+      }
+      return jsonResponse(res, 503, {
+        error: {
+          type: "server_error",
+          message: "Cron engine is not running. Background jobs require the cron engine.",
+        },
+      });
+    }
+
+    const jobId = body.id || `job_${randomUUID().replace(/-/g, "").slice(0, 16)}`;
+    const cronJobId = `bg-${jobId}`;
+    const sessionId = `${agentName}-${jobId}`;
+    const envelopedPrompt = buildEnvelope("background", prompt, { jobId, feedUrl: feedUrl(jobId), from: fromAgent });
+
+    try {
+      createOneShotCronJob(extDir, agentName, {
+        cronJobId,
+        prompt: envelopedPrompt,
+        sessionId,
+        model: body.model || null,
+        timeoutSeconds: Math.ceil(timeout / 1000),
+      });
+
+      createJob(extDir, agentName, { id: jobId, cronJobId, sessionId, prompt });
+
+      log.info(`background job created: ${jobId} (cron=${cronJobId}, session=${sessionId})`);
+
+      // Return both legacy feed_url and new session URLs
+      const response202 = build202Response(jobId, feedUrl(jobId));
+      response202.session_id = sessionId;
+      response202.session_url = sessionUrl(sessionId);
+      response202.session_json_url = `${sessionUrl(sessionId)}/json`;
+      jsonResponse(res, 202, response202);
+    } catch (err) {
+      log.error(`failed to create background job: ${err.message}`);
+      jsonResponse(res, 500, {
+        error: {
+          type: "server_error",
+          message: "Failed to create background job",
+          detail: err.message,
+        },
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /jobs — list background jobs
+  // ---------------------------------------------------------------------------
+
+  function handleListJobs(req, res) {
+    const agentName = state.agentName;
+    if (!agentName) {
+      return jsonResponse(res, 200, { jobs: [] });
+    }
+
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const statusFilter = url.searchParams.get("status");
+    const limit = parseInt(url.searchParams.get("limit"), 10) || 0;
+
+    let jobs = listJobs(extDir, agentName);
+
+    // Resolve each job's status lazily
+    jobs = jobs.map((job) => {
+      const resolved = resolveJobStatus(extDir, agentName, job.id);
+      return {
+        id: job.id,
+        status: resolved?.status || job.status,
+        prompt: job.prompt.length > 100 ? job.prompt.slice(0, 100) + "..." : job.prompt,
+        createdAt: job.createdAt,
+        updatedAt: job.updatedAt,
+        feed_url: feedUrl(job.id),
+      };
+    });
+
+    if (statusFilter) {
+      jobs = jobs.filter((j) => j.status === statusFilter);
+    }
+    if (limit > 0) {
+      jobs = jobs.slice(0, limit);
+    }
+
+    jsonResponse(res, 200, { jobs });
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /jobs/:id — single job detail
+  // ---------------------------------------------------------------------------
+
+  function handleGetJob(_req, res, jobId) {
+    const agentName = state.agentName;
+    if (!agentName) {
+      return jsonResponse(res, 404, { error: "Job not found", id: jobId });
+    }
+
+    const job = getJob(extDir, agentName, jobId);
+    if (!job) {
+      return jsonResponse(res, 404, { error: "Job not found", id: jobId });
+    }
+
+    const resolved = resolveJobStatus(extDir, agentName, jobId);
+    jsonResponse(res, 200, {
+      id: job.id,
+      status: resolved?.status || job.status,
+      prompt: job.prompt,
+      sessionId: job.sessionId,
+      cronJobId: job.cronJobId,
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+      feed_url: feedUrl(job.id),
+      response: resolved?.response || null,
+      statusItems: resolved?.statusItems || [],
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /feed/:jobId — RSS 2.0 XML feed
+  // ---------------------------------------------------------------------------
+
+  function handleFeed(_req, res, jobId) {
+    const agentName = state.agentName;
+    if (!agentName) {
+      return jsonResponse(res, 404, { error: "Job not found", id: jobId });
+    }
+
+    const job = getJob(extDir, agentName, jobId);
+    if (!job) {
+      return jsonResponse(res, 404, { error: "Job not found", id: jobId });
+    }
+
+    const resolved = resolveJobStatus(extDir, agentName, jobId);
+    const xml = buildRssFeed(
+      { ...job, status: resolved?.status || job.status },
+      resolved?.statusItems || [],
+      port,
+    );
+    xmlResponse(res, 200, xml);
+  }
+
+  // ---------------------------------------------------------------------------
+  // DELETE /jobs/:id — cancel or delete a job
+  // ---------------------------------------------------------------------------
+
+  function handleDeleteJob(_req, res, jobId) {
+    const agentName = state.agentName;
+    if (!agentName) {
+      return jsonResponse(res, 404, { error: "Job not found", id: jobId });
+    }
+
+    const job = getJob(extDir, agentName, jobId);
+    if (!job) {
+      return jsonResponse(res, 404, { error: "Job not found", id: jobId });
+    }
+
+    const resolved = resolveJobStatus(extDir, agentName, jobId);
+    const currentStatus = resolved?.status || job.status;
+    const terminalStates = new Set(["completed", "failed", "cancelled"]);
+
+    if (!terminalStates.has(currentStatus)) {
+      // Running or queued — cancel the cron job first
+      try {
+        const cronJobPath = pathResolve(extDir, "..", "cron", "data", agentName, "jobs", `${job.cronJobId}.json`);
+        const cronJob = JSON.parse(readFileSync(cronJobPath, "utf-8"));
+        if (cronJob.status === "enabled") {
+          cronJob.status = "disabled";
+          cronJob.nextRunAtUtc = null;
+          writeFileSync(cronJobPath, JSON.stringify(cronJob, null, 2), "utf-8");
+        }
+      } catch {
+        // Cron job may have already fired or been cleaned up
+      }
+    }
+
+    // Delete the job registry file and progress file
+    removeJob(extDir, agentName, jobId);
+    removeProgressFile(extDir, agentName, jobId);
+
+    const message = terminalStates.has(currentStatus)
+      ? `Job deleted (was ${currentStatus}).`
+      : currentStatus === "queued"
+        ? "Job cancelled and deleted before execution."
+        : "Job cancelled and deleted. Running execution may continue to completion.";
+
+    jsonResponse(res, 200, { id: jobId, status: "deleted", previousStatus: currentStatus, message });
+  }
+
+  // ---------------------------------------------------------------------------
+  // DELETE /jobs — bulk-delete all terminal jobs
+  // ---------------------------------------------------------------------------
+
+  function handleDeleteAllJobs(_req, res) {
+    const agentName = state.agentName;
+    if (!agentName) {
+      return jsonResponse(res, 200, { deleted: 0, kept: 0 });
+    }
+
+    const terminalStates = new Set(["completed", "failed", "cancelled"]);
+    const jobs = listJobs(extDir, agentName);
+    let deleted = 0;
+    let kept = 0;
+
+    for (const job of jobs) {
+      const resolved = resolveJobStatus(extDir, agentName, job.id);
+      const status = resolved?.status || job.status;
+      if (terminalStates.has(status)) {
+        removeJob(extDir, agentName, job.id);
+        removeProgressFile(extDir, agentName, job.id);
+        deleted++;
+      } else {
+        kept++;
+      }
+    }
+
+    jsonResponse(res, 200, { deleted, kept });
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /sessions — list sessions from session-store.db
+  // ---------------------------------------------------------------------------
+
+  function handleListSessions(req, res) {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const prefix = url.searchParams.get("prefix") || "";
+    const since = url.searchParams.get("since") || "";
+    const limit = parseInt(url.searchParams.get("limit"), 10) || 50;
+
+    let sql = "SELECT id, cwd, repository, branch, summary, created_at, updated_at FROM sessions WHERE 1=1";
+    const params = [];
+
+    if (prefix) {
+      sql += " AND id LIKE ?";
+      params.push(`${prefix}%`);
+    }
+    if (since) {
+      sql += " AND created_at >= ?";
+      params.push(since);
+    }
+    sql += " ORDER BY created_at DESC LIMIT ?";
+    params.push(limit);
+
+    const rows = querySessionStore(sql, params);
+    const sessions = rows.map((r) => ({
+      id: r.id,
+      summary: r.summary || null,
+      repository: r.repository || null,
+      branch: r.branch || null,
+      created_at: r.created_at,
+      updated_at: r.updated_at,
+      feed_url: sessionUrl(r.id),
+    }));
+
+    jsonResponse(res, 200, { sessions });
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /sessions/:id — RSS 2.0 feed from events.jsonl
+  // ---------------------------------------------------------------------------
+
+  function handleGetSessionRSS(_req, res, sessionId) {
+    const info = readSession(sessionId);
+    if (!info) {
+      return jsonResponse(res, 404, { error: "Session not found", id: sessionId });
+    }
+
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const xml = buildSessionRSS(sessionId, info.prompt || sessionId, baseUrl, info.timeline);
+    xmlResponse(res, 200, xml);
+  }
+
+  // ---------------------------------------------------------------------------
+  // GET /sessions/:id/json — JSON status + response + timeline
+  // ---------------------------------------------------------------------------
+
+  function handleGetSessionJSON(_req, res, sessionId) {
+    const info = readSession(sessionId);
+    if (!info) {
+      return jsonResponse(res, 404, { error: "Session not found", id: sessionId });
+    }
+
+    jsonResponse(res, 200, {
+      id: sessionId,
+      status: info.status,
+      response: info.response,
+      fullText: info.fullText || null,
+      prompt: info.prompt || null,
+      timeline: info.timeline || [],
+      feed_url: sessionUrl(sessionId),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Request router
+  // ---------------------------------------------------------------------------
+
+  function handleRequest(req, res) {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const path = url.pathname;
+
+    log.debug(`${req.method} ${path}`);
+
+    // CORS preflight
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, corsHeaders());
+      return res.end();
+    }
+
+    if (path === "/health" && req.method === "GET") return handleHealth(req, res);
+    if (path === "/history" && req.method === "GET") return handleHistory(req, res);
+    if (path === "/v1/responses" && req.method === "POST") return handleResponses(req, res);
+    if (path === "/jobs" && req.method === "GET") return handleListJobs(req, res);
+    if (path === "/jobs" && req.method === "DELETE") return handleDeleteAllJobs(req, res);
+
+    // /jobs/:id
+    const jobMatch = path.match(/^\/jobs\/([^/]+)$/);
+    if (jobMatch && req.method === "GET") return handleGetJob(req, res, decodeURIComponent(jobMatch[1]));
+    if (jobMatch && req.method === "DELETE") return handleDeleteJob(req, res, decodeURIComponent(jobMatch[1]));
+
+    // /feed/:jobId (legacy)
+    const feedMatch = path.match(/^\/feed\/([^/]+)$/);
+    if (feedMatch && req.method === "GET") return handleFeed(req, res, decodeURIComponent(feedMatch[1]));
+
+    // --- Session RSS routes (#49) ---
+    if (path === "/sessions" && req.method === "GET") return handleListSessions(req, res);
+
+    // /sessions/:id/json
+    const sessionJsonMatch = path.match(/^\/sessions\/([^/]+)\/json$/);
+    if (sessionJsonMatch && req.method === "GET") return handleGetSessionJSON(req, res, decodeURIComponent(sessionJsonMatch[1]));
+
+    // /sessions/:id (RSS)
+    const sessionMatch = path.match(/^\/sessions\/([^/]+)$/);
+    if (sessionMatch && req.method === "GET") return handleGetSessionRSS(req, res, decodeURIComponent(sessionMatch[1]));
+
+    jsonResponse(res, 404, {
+      error: "Not found",
+      endpoints: {
+        "POST /v1/responses": "OpenAI Responses API (async-default, 202 + RSS feed URL)",
+        "GET /sessions": "List sessions (filterable: ?prefix=, ?since=, ?limit=)",
+        "GET /sessions/:id": "RSS 2.0 XML feed for session events",
+        "GET /sessions/:id/json": "JSON status + response + timeline",
+        "GET /jobs": "List background jobs (legacy)",
+        "GET /jobs/:id": "Single job detail (legacy)",
+        "GET /feed/:jobId": "RSS 2.0 XML feed for job progress (legacy)",
+        "DELETE /jobs": "Delete all terminal jobs",
+        "DELETE /jobs/:id": "Delete a specific job",
+        "GET /history?limit=N": "Conversation history",
+        "GET /health": "Health check",
+      },
+    });
+  }
+
+  return {
+    start(requestedPort = 0) {
+      return new Promise((resolve, reject) => {
+        server = createServer(handleRequest);
+        server.listen(requestedPort, "127.0.0.1", () => {
+          port = server.address().port;
+          resolve(port);
+        });
+        server.on("error", reject);
+      });
+    },
+
+    stop() {
+      return new Promise((resolve) => {
+        if (!server) return resolve();
+        sseClients.forEach((c) => c.end());
+        sseClients.length = 0;
+        server.close(() => {
+          server = null;
+          port = null;
+          resolve();
+        });
+      });
+    },
+
+    bindSession(deps) {
+      session = deps;
+    },
+
+    getPort() {
+      return port;
+    },
+
+    isRunning() {
+      return server !== null;
+    },
+  };
+}

--- a/.github/extensions/responses/lib/server.test.mjs
+++ b/.github/extensions/responses/lib/server.test.mjs
@@ -1,0 +1,790 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync,
+  readdirSync, unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { request } from "node:http";
+
+import { createChatApiServer } from "./server.mjs";
+
+// ---------------------------------------------------------------------------
+// Shared HTTP helper
+// ---------------------------------------------------------------------------
+
+function httpRequest(method, portNum, path, body) {
+  return new Promise((resolve, reject) => {
+    const opts = {
+      hostname: "127.0.0.1",
+      port: portNum,
+      path,
+      method,
+      headers: { "Content-Type": "application/json" },
+    };
+    const req = request(opts, (res) => {
+      const chunks = [];
+      res.on("data", (c) => chunks.push(c));
+      res.on("end", () => {
+        const text = Buffer.concat(chunks).toString();
+        try {
+          resolve({ status: res.statusCode, body: JSON.parse(text), headers: res.headers });
+        } catch {
+          resolve({ status: res.statusCode, body: text, headers: res.headers });
+        }
+      });
+    });
+    req.on("error", reject);
+    if (body !== undefined) req.write(typeof body === "string" ? body : JSON.stringify(body));
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: write a job file directly into the bg-jobs dir
+// ---------------------------------------------------------------------------
+
+function writeJobFile(extDir, jobId, overrides = {}) {
+  const now = new Date().toISOString();
+  const job = {
+    id: jobId,
+    cronJobId: `bg-${jobId}`,
+    sessionId: `test-agent-${jobId}`,
+    prompt: "test prompt",
+    status: "queued",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+  writeFileSync(
+    join(extDir, "data", "test-agent", "bg-jobs", `${jobId}.json`),
+    JSON.stringify(job, null, 2),
+  );
+  return job;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: write a cron job file
+// ---------------------------------------------------------------------------
+
+function writeCronJobFile(tmpBase, cronJobId, overrides = {}) {
+  const cronJob = {
+    id: cronJobId,
+    name: cronJobId,
+    status: "enabled",
+    maxConcurrency: 1,
+    createdAtUtc: new Date().toISOString(),
+    lastRunAtUtc: null,
+    nextRunAtUtc: new Date(Date.now() + 60_000).toISOString(),
+    schedule: { type: "oneShot", fireAtUtc: new Date(Date.now() + 60_000).toISOString() },
+    payload: { type: "prompt", prompt: "test", model: null, sessionId: null, timeoutSeconds: 300 },
+    backoff: null,
+    source: "responses",
+    ...overrides,
+  };
+  writeFileSync(
+    join(tmpBase, "cron", "data", "test-agent", "jobs", `${cronJobId}.json`),
+    JSON.stringify(cronJob, null, 2),
+  );
+  return cronJob;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: write a cron history file
+// ---------------------------------------------------------------------------
+
+function writeHistoryFile(tmpBase, cronJobId, records) {
+  writeFileSync(
+    join(tmpBase, "cron", "data", "test-agent", "history", `${cronJobId}.json`),
+    JSON.stringify(records, null, 2),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GET /health
+// ---------------------------------------------------------------------------
+
+describe("GET /health", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port;
+
+  before(async () => {
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-health-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "test-agent", "bg-jobs"), { recursive: true });
+    state = { agentName: "test-agent" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns 200 with status ok", async () => {
+    const res = await httpRequest("GET", port, "/health");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.status, "ok");
+    assert.equal(res.body.session, "connected");
+    assert.equal(typeof res.body.port, "number");
+    assert.equal(typeof res.body.uptime, "number");
+    assert.equal(typeof res.body.timestamp, "number");
+  });
+
+  it("includes job count (zero initially)", async () => {
+    const res = await httpRequest("GET", port, "/health");
+    assert.equal(res.body.jobs, 0);
+  });
+
+  it("reflects job count after adding jobs", async () => {
+    writeJobFile(extDir, "health-j1");
+    writeJobFile(extDir, "health-j2");
+    const res = await httpRequest("GET", port, "/health");
+    assert.equal(res.body.jobs, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /jobs
+// ---------------------------------------------------------------------------
+
+describe("GET /jobs", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port;
+
+  before(async () => {
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-jobs-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "test-agent", "bg-jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "history"), { recursive: true });
+    state = { agentName: "test-agent" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns empty jobs array initially", async () => {
+    const res = await httpRequest("GET", port, "/jobs");
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(res.body.jobs));
+    assert.equal(res.body.jobs.length, 0);
+  });
+
+  it("returns jobs after creating them", async () => {
+    writeJobFile(extDir, "list-j1", { prompt: "first job" });
+    writeJobFile(extDir, "list-j2", { prompt: "second job" });
+    const res = await httpRequest("GET", port, "/jobs");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.jobs.length, 2);
+    const ids = res.body.jobs.map((j) => j.id);
+    assert.ok(ids.includes("list-j1"));
+    assert.ok(ids.includes("list-j2"));
+  });
+
+  it("each job has a feed_url", async () => {
+    const res = await httpRequest("GET", port, "/jobs");
+    for (const job of res.body.jobs) {
+      assert.ok(job.feed_url.includes(`/feed/${job.id}`));
+    }
+  });
+
+  it("supports status filter", async () => {
+    writeJobFile(extDir, "list-j3", { prompt: "cancelled", status: "cancelled" });
+    const res = await httpRequest("GET", port, "/jobs?status=cancelled");
+    assert.equal(res.status, 200);
+    assert.ok(res.body.jobs.length >= 1);
+    for (const j of res.body.jobs) {
+      assert.equal(j.status, "cancelled");
+    }
+  });
+
+  it("supports limit parameter", async () => {
+    const res = await httpRequest("GET", port, "/jobs?limit=1");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.jobs.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /jobs/:id
+// ---------------------------------------------------------------------------
+
+describe("GET /jobs/:id", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port;
+
+  before(async () => {
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-jobid-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "test-agent", "bg-jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "history"), { recursive: true });
+    state = { agentName: "test-agent" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns 404 for non-existent job", async () => {
+    const res = await httpRequest("GET", port, "/jobs/nonexistent");
+    assert.equal(res.status, 404);
+    assert.ok(res.body.error);
+  });
+
+  it("returns job detail for existing job", async () => {
+    writeJobFile(extDir, "detail-j1", { prompt: "my detailed prompt" });
+    const res = await httpRequest("GET", port, "/jobs/detail-j1");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.id, "detail-j1");
+    assert.equal(res.body.prompt, "my detailed prompt");
+    assert.ok(res.body.createdAt);
+    assert.ok(res.body.updatedAt);
+    assert.ok(Array.isArray(res.body.statusItems));
+  });
+
+  it("includes feed_url in response", async () => {
+    const res = await httpRequest("GET", port, "/jobs/detail-j1");
+    assert.equal(res.status, 200);
+    assert.ok(res.body.feed_url);
+    assert.ok(res.body.feed_url.includes("/feed/detail-j1"));
+  });
+
+  it("returns response field with output from cron history", async () => {
+    writeJobFile(extDir, "detail-j2", { prompt: "tell me about travel" });
+    writeCronJobFile(tmpBase, "bg-detail-j2", {
+      status: "disabled",
+      schedule: { type: "oneShot", fireAtUtc: new Date().toISOString() },
+    });
+    writeHistoryFile(tmpBase, "bg-detail-j2", [{
+      runId: "run-1",
+      jobId: "bg-detail-j2",
+      startedAtUtc: new Date(Date.now() - 5000).toISOString(),
+      completedAtUtc: new Date().toISOString(),
+      outcome: "success",
+      errorMessage: null,
+      durationMs: 5000,
+      output: "Here are the top travel destinations for 2026.",
+    }]);
+    const res = await httpRequest("GET", port, "/jobs/detail-j2");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.status, "completed");
+    assert.equal(res.body.response, "Here are the top travel destinations for 2026.");
+    const responseSI = res.body.statusItems.find((si) => si.title === "Response");
+    assert.ok(responseSI, "should have a Response status item");
+    assert.ok(responseSI.description.includes("travel destinations"));
+  });
+
+  it("returns null response when job is still queued", async () => {
+    writeJobFile(extDir, "detail-j3", { prompt: "pending job" });
+    const res = await httpRequest("GET", port, "/jobs/detail-j3");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.response, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /feed/:jobId
+// ---------------------------------------------------------------------------
+
+describe("GET /feed/:jobId", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port;
+
+  before(async () => {
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-feed-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "test-agent", "bg-jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "history"), { recursive: true });
+    state = { agentName: "test-agent" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns 404 for non-existent job", async () => {
+    const res = await httpRequest("GET", port, "/feed/nonexistent");
+    assert.equal(res.status, 404);
+  });
+
+  it("returns RSS XML for existing job", async () => {
+    writeJobFile(extDir, "feed-j1", { prompt: "rss test prompt" });
+    const res = await httpRequest("GET", port, "/feed/feed-j1");
+    assert.equal(res.status, 200);
+    assert.ok(res.headers["content-type"].includes("application/rss+xml"));
+    // body is raw XML string since it won't parse as JSON
+    assert.equal(typeof res.body, "string");
+    assert.ok(res.body.includes("<?xml"));
+    assert.ok(res.body.includes("<rss"));
+  });
+
+  it("XML contains job ID", async () => {
+    const res = await httpRequest("GET", port, "/feed/feed-j1");
+    assert.ok(res.body.includes("feed-j1"));
+  });
+
+  it("includes content:encoded with full response from cron history", async () => {
+    const fullResponse = "This is a detailed AI response about travel destinations that exceeds the truncation limit and should appear in full inside content:encoded CDATA.";
+    writeJobFile(extDir, "feed-j2", { prompt: "travel destinations" });
+    writeCronJobFile(tmpBase, "bg-feed-j2", {
+      status: "disabled",
+      schedule: { type: "oneShot", fireAtUtc: new Date().toISOString() },
+    });
+    writeHistoryFile(tmpBase, "bg-feed-j2", [{
+      runId: "run-1",
+      jobId: "bg-feed-j2",
+      startedAtUtc: new Date(Date.now() - 5000).toISOString(),
+      completedAtUtc: new Date().toISOString(),
+      outcome: "success",
+      errorMessage: null,
+      durationMs: 5000,
+      output: fullResponse,
+    }]);
+    const res = await httpRequest("GET", port, "/feed/feed-j2");
+    assert.equal(res.status, 200);
+    assert.ok(res.body.includes("content:encoded"), "should contain content:encoded element");
+    assert.ok(res.body.includes("<![CDATA["), "should contain CDATA section");
+    assert.ok(res.body.includes(fullResponse), "should contain the full response text");
+    assert.ok(res.body.includes("xmlns:content"), "should include content namespace");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /jobs/:id
+// ---------------------------------------------------------------------------
+
+describe("DELETE /jobs/:id", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port;
+
+  before(async () => {
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-del-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "test-agent", "bg-jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "history"), { recursive: true });
+    state = { agentName: "test-agent" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns 404 for non-existent job", async () => {
+    const res = await httpRequest("DELETE", port, "/jobs/nonexistent");
+    assert.equal(res.status, 404);
+    assert.ok(res.body.error);
+  });
+
+  it("cancels and deletes a queued job", async () => {
+    writeJobFile(extDir, "del-j1");
+    writeCronJobFile(tmpBase, "bg-del-j1");
+
+    const res = await httpRequest("DELETE", port, "/jobs/del-j1");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.status, "deleted");
+    assert.equal(res.body.previousStatus, "queued");
+    assert.equal(res.body.id, "del-j1");
+
+    // Verify job file was removed
+    assert.ok(
+      !existsSync(join(extDir, "data", "test-agent", "bg-jobs", "del-j1.json")),
+      "job file should be deleted",
+    );
+
+    // Verify cron job was disabled
+    const updatedCron = JSON.parse(
+      readFileSync(join(tmpBase, "cron", "data", "test-agent", "jobs", "bg-del-j1.json"), "utf-8"),
+    );
+    assert.equal(updatedCron.status, "disabled");
+    assert.equal(updatedCron.nextRunAtUtc, null);
+  });
+
+  it("deletes an already-cancelled job", async () => {
+    writeJobFile(extDir, "del-j2", { status: "cancelled" });
+    const res = await httpRequest("DELETE", port, "/jobs/del-j2");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.status, "deleted");
+    assert.equal(res.body.previousStatus, "cancelled");
+    assert.ok(
+      !existsSync(join(extDir, "data", "test-agent", "bg-jobs", "del-j2.json")),
+      "job file should be deleted",
+    );
+  });
+
+  it("deletes a completed job", async () => {
+    writeJobFile(extDir, "del-j3");
+    writeFileSync(
+      join(tmpBase, "cron", "data", "test-agent", "history", "bg-del-j3.json"),
+      JSON.stringify([{
+        outcome: "success",
+        startedAtUtc: new Date().toISOString(),
+        completedAtUtc: new Date().toISOString(),
+        durationMs: 100,
+      }]),
+    );
+    const res = await httpRequest("DELETE", port, "/jobs/del-j3");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.status, "deleted");
+    assert.equal(res.body.previousStatus, "completed");
+    assert.ok(
+      !existsSync(join(extDir, "data", "test-agent", "bg-jobs", "del-j3.json")),
+      "job file should be deleted",
+    );
+  });
+
+  it("also deletes the progress file alongside the job", async () => {
+    writeJobFile(extDir, "del-j4", { status: "cancelled" });
+    const progressPath = join(extDir, "data", "test-agent", "bg-jobs", "del-j4.progress.jsonl");
+    writeFileSync(progressPath, '{"type":"test","title":"t","timestamp":"t"}\n');
+
+    const res = await httpRequest("DELETE", port, "/jobs/del-j4");
+    assert.equal(res.status, 200);
+    assert.ok(!existsSync(progressPath), "progress file should be deleted");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /jobs — bulk delete terminal jobs
+// ---------------------------------------------------------------------------
+
+describe("DELETE /jobs", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port;
+
+  before(async () => {
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-delbulk-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "test-agent", "bg-jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "history"), { recursive: true });
+    state = { agentName: "test-agent" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("deletes terminal jobs and keeps running ones", async () => {
+    // Terminal jobs — need cron history so resolveJobStatus sees them as terminal
+    writeJobFile(extDir, "bulk-done");
+    writeHistoryFile(tmpBase, "bg-bulk-done", [
+      { outcome: "success", completedAtUtc: new Date().toISOString(), durationMs: 100 },
+    ]);
+    writeJobFile(extDir, "bulk-fail");
+    writeHistoryFile(tmpBase, "bg-bulk-fail", [
+      { outcome: "failure", errorMessage: "timeout", completedAtUtc: new Date().toISOString(), durationMs: 100 },
+    ]);
+    writeJobFile(extDir, "bulk-cancel", { status: "cancelled" });
+    // Write a progress file for one
+    writeFileSync(
+      join(extDir, "data", "test-agent", "bg-jobs", "bulk-done.progress.jsonl"),
+      '{"type":"test","title":"t","timestamp":"t"}\n',
+    );
+
+    // Non-terminal job (cron hasn't fired yet, no history → status stays "queued")
+    writeJobFile(extDir, "bulk-active");
+    writeCronJobFile(tmpBase, "bg-bulk-active");
+
+    const res = await httpRequest("DELETE", port, "/jobs");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.deleted, 3);
+    assert.equal(res.body.kept, 1);
+
+    // Terminal jobs should be gone
+    assert.ok(!existsSync(join(extDir, "data", "test-agent", "bg-jobs", "bulk-done.json")));
+    assert.ok(!existsSync(join(extDir, "data", "test-agent", "bg-jobs", "bulk-done.progress.jsonl")));
+    assert.ok(!existsSync(join(extDir, "data", "test-agent", "bg-jobs", "bulk-fail.json")));
+    assert.ok(!existsSync(join(extDir, "data", "test-agent", "bg-jobs", "bulk-cancel.json")));
+
+    // Active job should remain
+    assert.ok(existsSync(join(extDir, "data", "test-agent", "bg-jobs", "bulk-active.json")));
+  });
+
+  it("returns zeros when no jobs exist", async () => {
+    // Clean up from previous test
+    const bgDir = join(extDir, "data", "test-agent", "bg-jobs");
+    for (const f of readdirSync(bgDir)) {
+      unlinkSync(join(bgDir, f));
+    }
+
+    const res = await httpRequest("DELETE", port, "/jobs");
+    assert.equal(res.status, 200);
+    assert.equal(res.body.deleted, 0);
+    assert.equal(res.body.kept, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/responses
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/responses", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port;
+
+  before(async () => {
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-resp-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "test-agent", "bg-jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "history"), { recursive: true });
+    state = { agentName: "test-agent" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+    server.bindSession({
+      sendAndWait: async (p) => ({ data: { content: "hello" } }),
+      send: async () => {},
+      getMessages: async () => [],
+      onEvent: () => () => {},
+    });
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns 400 for missing input", async () => {
+    const res = await httpRequest("POST", port, "/v1/responses", {});
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error);
+    assert.ok(res.body.error.message.includes("input"));
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const res = await httpRequest("POST", port, "/v1/responses", "not json {{{");
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.message.includes("Invalid JSON"));
+  });
+
+  it("returns 503 when cron engine not running (default async mode)", async () => {
+    const res = await httpRequest("POST", port, "/v1/responses", { input: "run in background" });
+    assert.equal(res.status, 503);
+    assert.ok(res.body.error.message.toLowerCase().includes("cron"));
+  });
+
+  it("returns 200 with completed response in sync mode", async () => {
+    const res = await httpRequest("POST", port, "/v1/responses", {
+      input: "hello sync",
+      async: false,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.status, "completed");
+    assert.equal(res.body.output_text, "hello");
+    assert.equal(res.body.object, "response");
+    assert.ok(res.body.id.startsWith("resp_"));
+    assert.ok(Array.isArray(res.body.output));
+  });
+
+  it("returns 502 when session.sendAndWait throws in sync mode", async () => {
+    // Create a separate server with a failing session
+    const tmpFail = mkdtempSync(join(tmpdir(), "srv-fail-"));
+    const extFail = join(tmpFail, "responses");
+    mkdirSync(join(extFail, "data", "test-agent", "bg-jobs"), { recursive: true });
+    const failState = { agentName: "test-agent" };
+    const failServer = createChatApiServer(log, extFail, failState);
+    const failPort = await failServer.start(0);
+    failServer.bindSession({
+      sendAndWait: async () => { throw new Error("session exploded"); },
+      send: async () => {},
+      getMessages: async () => [],
+      onEvent: () => () => {},
+    });
+
+    try {
+      const res = await httpRequest("POST", failPort, "/v1/responses", {
+        input: "will fail",
+        async: false,
+      });
+      assert.equal(res.status, 502);
+      assert.ok(res.body.error.message.includes("Agent failed"));
+    } finally {
+      await failServer.stop();
+      rmSync(tmpFail, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/responses — async mode with running cron engine
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/responses async with cron engine", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port, savedEnv;
+
+  before(async () => {
+    savedEnv = process.env.COPILOT_AGENT;
+    process.env.COPILOT_AGENT = "test-agent";
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-async-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "test-agent", "bg-jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "test-agent", "history"), { recursive: true });
+
+    // Fake cron engine lockfile with current PID so isCronEngineRunning returns true
+    writeFileSync(
+      join(tmpBase, "cron", "data", "test-agent", "engine.lock"),
+      String(process.pid),
+    );
+
+    state = { agentName: "test-agent" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+    server.bindSession({
+      sendAndWait: async () => ({ data: { content: "bg response" } }),
+      send: async () => {},
+      getMessages: async () => [],
+      onEvent: () => () => {},
+    });
+  });
+
+  after(async () => {
+    await server.stop();
+    if (savedEnv === undefined) delete process.env.COPILOT_AGENT;
+    else process.env.COPILOT_AGENT = savedEnv;
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns 202 with queued status and feed_url", async () => {
+    const res = await httpRequest("POST", port, "/v1/responses", { input: "background task" });
+    assert.equal(res.status, 202);
+    assert.equal(res.body.status, "queued");
+    assert.equal(res.body.object, "response");
+    assert.ok(res.body.id);
+    assert.ok(res.body.feed_url);
+    assert.ok(res.body.feed_url.includes("/feed/"));
+  });
+
+  it("creates job and cron files on disk", async () => {
+    const res = await httpRequest("POST", port, "/v1/responses", {
+      input: "disk check",
+      id: "custom-job-id",
+    });
+    assert.equal(res.status, 202);
+    assert.equal(res.body.id, "custom-job-id");
+
+    // Verify bg-job file
+    const jobPath = join(extDir, "data", "test-agent", "bg-jobs", "custom-job-id.json");
+    const job = JSON.parse(readFileSync(jobPath, "utf-8"));
+    assert.equal(job.id, "custom-job-id");
+    assert.equal(job.status, "queued");
+    assert.equal(job.prompt, "disk check");
+
+    // Verify cron job file
+    const cronPath = join(tmpBase, "cron", "data", "test-agent", "jobs", "bg-custom-job-id.json");
+    const cronJob = JSON.parse(readFileSync(cronPath, "utf-8"));
+    assert.equal(cronJob.id, "bg-custom-job-id");
+    assert.equal(cronJob.status, "enabled");
+    assert.equal(cronJob.schedule.type, "oneShot");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/responses — agent namespace mismatch
+// ---------------------------------------------------------------------------
+
+describe("POST /v1/responses agent namespace mismatch", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port;
+
+  before(async () => {
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-mismatch-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "scotty", "bg-jobs"), { recursive: true });
+    mkdirSync(join(tmpBase, "cron", "data", "different-agent"), { recursive: true });
+
+    // Engine lockfile under a DIFFERENT agent namespace — no lockfile for "scotty"
+    writeFileSync(
+      join(tmpBase, "cron", "data", "different-agent", "engine.lock"),
+      String(process.pid),
+    );
+
+    state = { agentName: "scotty" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+    server.bindSession({
+      sendAndWait: async () => ({ data: { content: "unused" } }),
+      send: async () => {},
+      getMessages: async () => [],
+      onEvent: () => () => {},
+    });
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns 409 with informative error listing running engines", async () => {
+    const res = await httpRequest("POST", port, "/v1/responses", { input: "test" });
+    assert.equal(res.status, 409);
+    assert.equal(res.body.error.type, "configuration_error");
+    assert.ok(res.body.error.message.includes("scotty"), "should mention responses agent");
+    assert.ok(res.body.error.message.includes("different-agent"), "should mention running engine");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 404 handler
+// ---------------------------------------------------------------------------
+
+describe("404 handler", () => {
+  const log = { info() {}, error() {}, debug() {} };
+  let tmpBase, extDir, state, server, port;
+
+  before(async () => {
+    tmpBase = mkdtempSync(join(tmpdir(), "srv-404-"));
+    extDir = join(tmpBase, "responses");
+    mkdirSync(join(extDir, "data", "test-agent", "bg-jobs"), { recursive: true });
+    state = { agentName: "test-agent" };
+    server = createChatApiServer(log, extDir, state);
+    port = await server.start(0);
+  });
+
+  after(async () => {
+    await server.stop();
+    rmSync(tmpBase, { recursive: true, force: true });
+  });
+
+  it("returns 404 with endpoint list for unknown paths", async () => {
+    const res = await httpRequest("GET", port, "/unknown/path");
+    assert.equal(res.status, 404);
+    assert.equal(res.body.error, "Not found");
+    assert.ok(res.body.endpoints);
+    assert.ok(res.body.endpoints["GET /health"]);
+    assert.ok(res.body.endpoints["POST /v1/responses"]);
+    assert.ok(res.body.endpoints["GET /jobs"]);
+    assert.ok(res.body.endpoints["GET /jobs/:id"]);
+    assert.ok(res.body.endpoints["DELETE /jobs"]);
+    assert.ok(res.body.endpoints["DELETE /jobs/:id"]);
+    assert.ok(res.body.endpoints["GET /feed/:jobId"]);
+  });
+
+  it("returns 404 for POST to unknown path", async () => {
+    const res = await httpRequest("POST", port, "/nope", {});
+    assert.equal(res.status, 404);
+  });
+});

--- a/.github/extensions/responses/lib/session-reader.mjs
+++ b/.github/extensions/responses/lib/session-reader.mjs
@@ -1,0 +1,137 @@
+import Database from "better-sqlite3";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { existsSync } from "node:fs";
+
+export function getSessionStorePath() {
+  return join(homedir(), ".copilot", "session-store.db");
+}
+
+function openDb() {
+  const dbPath = getSessionStorePath();
+  if (!existsSync(dbPath)) return null;
+  return new Database(dbPath, { readonly: true, fileMustExist: true });
+}
+
+export function getSessionTurns(sessionId) {
+  let db;
+  try {
+    db = openDb();
+    if (!db) return [];
+    const rows = db
+      .prepare(
+        "SELECT turn_index, user_message, assistant_response, timestamp FROM turns WHERE session_id = ? ORDER BY turn_index"
+      )
+      .all(sessionId);
+    return rows.map((r) => ({
+      turnIndex: r.turn_index,
+      userMessage: r.user_message,
+      assistantResponse: r.assistant_response,
+      timestamp: r.timestamp,
+    }));
+  } catch {
+    return [];
+  } finally {
+    db?.close();
+  }
+}
+
+export function getSessionCheckpoints(sessionId) {
+  let db;
+  try {
+    db = openDb();
+    if (!db) return [];
+    const rows = db
+      .prepare(
+        "SELECT checkpoint_number, title, overview, created_at FROM checkpoints WHERE session_id = ? ORDER BY checkpoint_number"
+      )
+      .all(sessionId);
+    return rows.map((r) => ({
+      number: r.checkpoint_number,
+      title: r.title,
+      overview: r.overview,
+      timestamp: r.created_at,
+    }));
+  } catch {
+    return [];
+  } finally {
+    db?.close();
+  }
+}
+
+export function getSessionFiles(sessionId) {
+  let db;
+  try {
+    db = openDb();
+    if (!db) return [];
+    const rows = db
+      .prepare(
+        "SELECT file_path, tool_name, first_seen_at FROM session_files WHERE session_id = ? ORDER BY first_seen_at"
+      )
+      .all(sessionId);
+    return rows.map((r) => ({
+      filePath: r.file_path,
+      toolName: r.tool_name,
+      timestamp: r.first_seen_at,
+    }));
+  } catch {
+    return [];
+  } finally {
+    db?.close();
+  }
+}
+
+function truncate(text, max = 200) {
+  if (!text) return "";
+  return text.length > max ? text.slice(0, max) : text;
+}
+
+export function buildStatusItemsFromSession(sessionId) {
+  const turns = getSessionTurns(sessionId);
+  const checkpoints = getSessionCheckpoints(sessionId);
+  const files = getSessionFiles(sessionId);
+
+  const items = [];
+
+  for (const t of turns) {
+    if (t.turnIndex === 0) {
+      items.push({
+        title: "Processing Started",
+        description: "Agent began processing.",
+        timestamp: t.timestamp,
+      });
+    } else {
+      items.push({
+        title: `Turn ${t.turnIndex}`,
+        description: truncate(t.assistantResponse),
+        timestamp: t.timestamp,
+        fullText: t.assistantResponse || null,
+      });
+    }
+  }
+
+  for (const cp of checkpoints) {
+    items.push({
+      title: `Checkpoint: ${cp.title}`,
+      description: truncate(cp.overview),
+      timestamp: cp.timestamp,
+    });
+  }
+
+  for (const f of files) {
+    const verb = f.toolName === "create" ? "Created" : "Edited";
+    items.push({
+      title: `File ${verb}: ${f.filePath}`,
+      description: `${verb} via ${f.toolName}`,
+      timestamp: f.timestamp,
+    });
+  }
+
+  items.sort((a, b) => {
+    if (a.timestamp < b.timestamp) return -1;
+    if (a.timestamp > b.timestamp) return 1;
+    return 0;
+  });
+
+  return items;
+}

--- a/.github/extensions/responses/lib/session-reader.test.mjs
+++ b/.github/extensions/responses/lib/session-reader.test.mjs
@@ -1,0 +1,160 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, sep } from "node:path";
+
+import {
+  getSessionStorePath,
+  getSessionTurns,
+  getSessionCheckpoints,
+  getSessionFiles,
+  buildStatusItemsFromSession,
+} from "./session-reader.mjs";
+
+// A sessionId guaranteed to never match real data
+const BOGUS_SESSION = "aaaaaaaa-0000-0000-0000-000000000000";
+
+// ---------------------------------------------------------------------------
+// getSessionStorePath
+// ---------------------------------------------------------------------------
+
+describe("getSessionStorePath", () => {
+  it("returns a string ending with session-store.db", () => {
+    const p = getSessionStorePath();
+    assert.equal(typeof p, "string");
+    assert.ok(p.endsWith("session-store.db"), `expected path ending with session-store.db, got: ${p}`);
+  });
+
+  it("path includes .copilot directory", () => {
+    const p = getSessionStorePath();
+    assert.ok(p.includes(`${sep}.copilot${sep}`), `expected .copilot in path, got: ${p}`);
+  });
+
+  it("path is rooted under homedir", () => {
+    const p = getSessionStorePath();
+    assert.ok(p.startsWith(homedir()), `expected path under homedir, got: ${p}`);
+  });
+
+  it("equals the expected full path", () => {
+    const expected = join(homedir(), ".copilot", "session-store.db");
+    assert.equal(getSessionStorePath(), expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSessionTurns — defensive behaviour
+// ---------------------------------------------------------------------------
+
+describe("getSessionTurns", () => {
+  it("returns an array for a bogus sessionId", () => {
+    const result = getSessionTurns(BOGUS_SESSION);
+    assert.ok(Array.isArray(result));
+  });
+
+  it("returns empty array when no turns match", () => {
+    const result = getSessionTurns(BOGUS_SESSION);
+    assert.deepEqual(result, []);
+  });
+
+  it("never throws", () => {
+    assert.doesNotThrow(() => getSessionTurns(undefined));
+    assert.doesNotThrow(() => getSessionTurns(null));
+    assert.doesNotThrow(() => getSessionTurns(""));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSessionCheckpoints — defensive behaviour
+// ---------------------------------------------------------------------------
+
+describe("getSessionCheckpoints", () => {
+  it("returns an array for a bogus sessionId", () => {
+    const result = getSessionCheckpoints(BOGUS_SESSION);
+    assert.ok(Array.isArray(result));
+  });
+
+  it("returns empty array when no checkpoints match", () => {
+    const result = getSessionCheckpoints(BOGUS_SESSION);
+    assert.deepEqual(result, []);
+  });
+
+  it("never throws", () => {
+    assert.doesNotThrow(() => getSessionCheckpoints(undefined));
+    assert.doesNotThrow(() => getSessionCheckpoints(null));
+    assert.doesNotThrow(() => getSessionCheckpoints(""));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSessionFiles — defensive behaviour
+// ---------------------------------------------------------------------------
+
+describe("getSessionFiles", () => {
+  it("returns an array for a bogus sessionId", () => {
+    const result = getSessionFiles(BOGUS_SESSION);
+    assert.ok(Array.isArray(result));
+  });
+
+  it("returns empty array when no files match", () => {
+    const result = getSessionFiles(BOGUS_SESSION);
+    assert.deepEqual(result, []);
+  });
+
+  it("never throws", () => {
+    assert.doesNotThrow(() => getSessionFiles(undefined));
+    assert.doesNotThrow(() => getSessionFiles(null));
+    assert.doesNotThrow(() => getSessionFiles(""));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildStatusItemsFromSession — defensive behaviour
+// ---------------------------------------------------------------------------
+
+describe("buildStatusItemsFromSession", () => {
+  it("returns an array for a bogus sessionId", () => {
+    const result = buildStatusItemsFromSession(BOGUS_SESSION);
+    assert.ok(Array.isArray(result));
+  });
+
+  it("returns empty array when no data matches", () => {
+    const result = buildStatusItemsFromSession(BOGUS_SESSION);
+    assert.deepEqual(result, []);
+  });
+
+  it("never throws", () => {
+    assert.doesNotThrow(() => buildStatusItemsFromSession(undefined));
+    assert.doesNotThrow(() => buildStatusItemsFromSession(null));
+    assert.doesNotThrow(() => buildStatusItemsFromSession(""));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Smoke tests against real session-store.db (skipped when DB is absent)
+// ---------------------------------------------------------------------------
+
+const dbExists = existsSync(getSessionStorePath());
+
+describe("with real session-store.db", { skip: !dbExists && "session-store.db not found" }, () => {
+  it("getSessionTurns returns array with expected shape", () => {
+    // Query with bogus id still returns [] — validates DB opens without error
+    const result = getSessionTurns(BOGUS_SESSION);
+    assert.ok(Array.isArray(result));
+  });
+
+  it("getSessionCheckpoints returns array with expected shape", () => {
+    const result = getSessionCheckpoints(BOGUS_SESSION);
+    assert.ok(Array.isArray(result));
+  });
+
+  it("getSessionFiles returns array with expected shape", () => {
+    const result = getSessionFiles(BOGUS_SESSION);
+    assert.ok(Array.isArray(result));
+  });
+
+  it("buildStatusItemsFromSession returns array with expected shape", () => {
+    const result = buildStatusItemsFromSession(BOGUS_SESSION);
+    assert.ok(Array.isArray(result));
+  });
+});

--- a/.github/extensions/responses/lib/session-rss.mjs
+++ b/.github/extensions/responses/lib/session-rss.mjs
@@ -1,0 +1,66 @@
+// session-rss.mjs — Build RSS 2.0 feeds from session events
+//
+// Generates standard RSS 2.0 XML from a session timeline.
+// Each event becomes an <item>. The response gets <content:encoded> for full text.
+
+/**
+ * Build an RSS 2.0 XML string from session data.
+ *
+ * @param {string} sessionId
+ * @param {string} prompt - The original prompt (for channel description)
+ * @param {string} baseUrl - Base URL for links (e.g., "http://127.0.0.1:15210")
+ * @param {Array<{title: string, description: string, timestamp: string, fullText?: string}>} timeline
+ * @returns {string} RSS 2.0 XML
+ */
+export function buildSessionRSS(sessionId, prompt, baseUrl, timeline) {
+  const link = `${baseUrl}/sessions/${encodeURIComponent(sessionId)}`;
+  const lastBuild = timeline.length > 0
+    ? new Date(timeline[timeline.length - 1].timestamp).toUTCString()
+    : new Date().toUTCString();
+
+  let xml = `<?xml version="1.0" encoding="UTF-8"?>\n`;
+  xml += `<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">\n`;
+  xml += `  <channel>\n`;
+  xml += `    <title>Session ${esc(sessionId)}</title>\n`;
+  xml += `    <link>${esc(link)}</link>\n`;
+  xml += `    <description>${esc(truncate(prompt || sessionId, 500))}</description>\n`;
+  xml += `    <language>en-us</language>\n`;
+  xml += `    <lastBuildDate>${lastBuild}</lastBuildDate>\n`;
+
+  for (const item of timeline) {
+    xml += `    <item>\n`;
+    xml += `      <title>${esc(item.title)}</title>\n`;
+    xml += `      <description>${esc(truncate(item.description, 500))}</description>\n`;
+    xml += `      <link>${esc(link)}</link>\n`;
+    if (item.timestamp) {
+      xml += `      <pubDate>${new Date(item.timestamp).toUTCString()}</pubDate>\n`;
+      xml += `      <guid isPermaLink="false">${esc(sessionId)}-${esc(item.timestamp)}</guid>\n`;
+    }
+    if (item.fullText) {
+      xml += `      <content:encoded><![CDATA[${item.fullText}]]></content:encoded>\n`;
+    }
+    xml += `    </item>\n`;
+  }
+
+  xml += `  </channel>\n`;
+  xml += `</rss>\n`;
+  return xml;
+}
+
+// --- Helpers ---
+
+function esc(text) {
+  if (!text) return "";
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function truncate(text, max = 200) {
+  if (!text) return "";
+  const s = String(text);
+  return s.length > max ? s.slice(0, max) + "…" : s;
+}

--- a/.github/extensions/responses/package.json
+++ b/.github/extensions/responses/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "copilot-responses-extension",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "better-sqlite3": "^11.0.0"
+  }
+}

--- a/.github/extensions/responses/tools/api-tools.mjs
+++ b/.github/extensions/responses/tools/api-tools.mjs
@@ -1,0 +1,101 @@
+import { removeLockfile, writeLockfile, cleanStaleLockfile, migrateLegacyData } from "../lib/lifecycle.mjs";
+import { loadConfig } from "../lib/config.mjs";
+import { getLockfilePath, getConfigPath, sanitizeAgentName } from "../lib/paths.mjs";
+import { listJobs } from "../lib/job-registry.mjs";
+
+/**
+ * Tools exposed to the agent for managing the Responses API server.
+ * @param {object} server - The HTTP server instance
+ * @param {string} extDir - Extension root directory
+ * @param {object} state  - Mutable state ({ agentName })
+ * @param {object} log    - Logger instance
+ */
+export function createApiTools(server, extDir, state, log) {
+  return [
+    {
+      name: "responses_status",
+      description:
+        "Get the status of the Responses API server, including its port and endpoints.",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+      handler: async () => {
+        if (!state.agentName) {
+          return "Responses API server is not running. Call responses_restart with agent parameter to claim a namespace and start the server.";
+        }
+
+        const port = server.getPort();
+        if (server.isRunning()) {
+          let jobCount = 0;
+          try { jobCount = listJobs(extDir, state.agentName).length; } catch { /* best effort */ }
+
+          return [
+            `Responses API server is running on http://127.0.0.1:${port} (agent: ${state.agentName})`,
+            `Background jobs: ${jobCount}`,
+            "",
+            "Endpoints:",
+            `  POST   http://127.0.0.1:${port}/v1/responses  — OpenAI Responses API (async-default, 202 + RSS)`,
+            `  GET    http://127.0.0.1:${port}/jobs            — list background jobs`,
+            `  GET    http://127.0.0.1:${port}/jobs/:id        — job detail + status items`,
+            `  GET    http://127.0.0.1:${port}/feed/:jobId     — RSS 2.0 feed for job progress`,
+            `  DELETE http://127.0.0.1:${port}/jobs            — delete all terminal jobs`,
+            `  DELETE http://127.0.0.1:${port}/jobs/:id        — delete a specific job`,
+            `  GET    http://127.0.0.1:${port}/history         — conversation history`,
+            `  GET    http://127.0.0.1:${port}/health          — health check`,
+          ].join("\n");
+        }
+
+        return "Responses API server is not running.";
+      },
+    },
+    {
+      name: "responses_restart",
+      description:
+        "Start or restart the Responses API server under a named agent namespace. The agent parameter is required.",
+      parameters: {
+        type: "object",
+        properties: {
+          agent: {
+            type: "string",
+            description:
+              "Agent namespace (e.g. 'fox', 'ender'). Determines config and lockfile paths under data/{agent}/. Required.",
+          },
+          port: {
+            type: "number",
+            description:
+              "Port override. Defaults to the configured port in data/{agent}/config.json.",
+          },
+        },
+        required: ["agent"],
+      },
+      handler: async (args) => {
+        const agentName = sanitizeAgentName(args.agent);
+        if (!agentName) {
+          return "Error: agent parameter is required and must contain valid characters [a-zA-Z0-9_-].";
+        }
+
+        // Stop existing server and clean up previous namespace
+        if (server.isRunning()) {
+          await server.stop();
+          if (state.agentName) {
+            removeLockfile(getLockfilePath(extDir, state.agentName));
+          }
+        }
+
+        state.agentName = agentName;
+        migrateLegacyData(extDir, agentName);
+
+        const lockPath = getLockfilePath(extDir, agentName);
+        cleanStaleLockfile(lockPath, log);
+
+        const config = loadConfig(getConfigPath(extDir, agentName));
+        const actualPort = await server.start(args.port || config.port);
+        writeLockfile(lockPath, process.pid, actualPort);
+
+        log.info(`server started on port ${actualPort} (agent=${agentName})`);
+        return `Responses API server started on http://127.0.0.1:${actualPort} (agent: ${agentName})`;
+      },
+    },
+  ];
+}

--- a/.github/registry.json
+++ b/.github/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.0",
+  "version": "0.8.0",
   "source": "ianphil/genesis-frontier",
   "extensions": {
     "heartbeat": {
@@ -21,6 +21,26 @@
       "version": "0.1.0",
       "path": ".github/extensions/microui",
       "description": "Lightweight native WebView windows — cross-platform micro-UI over JSON Lines (WebView2/WKWebView/WebKitGTK)"
+    },
+    "canvas": {
+      "version": "0.1.3",
+      "path": ".github/extensions/canvas",
+      "description": "Display rich HTML content in the browser with SSE live reload"
+    },
+    "cron": {
+      "version": "0.4.0",
+      "path": ".github/extensions/cron",
+      "description": "Scheduled job execution — cron, interval, and one-shot with prompt and command payloads"
+    },
+    "idea": {
+      "version": "0.1.0",
+      "path": ".github/extensions/idea",
+      "description": "IDEA mind search — keyword, semantic recall, reindex, and health across Initiatives, Domains, Expertise, and Archive"
+    },
+    "responses": {
+      "version": "0.9.0",
+      "path": ".github/extensions/responses",
+      "description": "OpenAI Responses API–compatible HTTP server — XML message envelopes with sender identification via X-Agent-Name header"
     }
   },
   "skills": {
@@ -43,6 +63,21 @@
       "version": "0.1.0",
       "path": ".github/skills/generate-agent",
       "description": "Generate a Copilot CLI agent with a distinct personality — produces agent file + soul file at repo or user scope"
+    },
+    "packages": {
+      "version": "0.2.0",
+      "path": ".github/skills/packages",
+      "description": "Install, remove, and manage extensions and skills from third-party Genesis packages"
+    },
+    "upgrade": {
+      "version": "0.6.0",
+      "path": ".github/skills/upgrade",
+      "description": "Pull new extensions and skills from the genesis template registry; migrate channel-based registries to package-based"
+    },
+    "yellow-pages": {
+      "version": "0.1.0",
+      "path": ".github/skills/yellow-pages",
+      "description": "Agent directory and unified comms — send messages to local or remote agents via contacts.json registry"
     }
   },
   "prompts": {},

--- a/.github/skills/packages/SKILL.md
+++ b/.github/skills/packages/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: packages
+description: Install, remove, and manage extensions and skills from third-party Genesis packages. Use when the user asks to install a package from another repo, list installed packages, remove a third-party package, or check for updates from a specific package source.
+---
+
+# Genesis Packages
+
+Install extensions and skills from any GitHub repository that follows the Genesis package format.
+
+**This skill includes `packages.js`** — a script that handles registry lookups, file downloads, conflict detection, and registry updates. Your job is to run it and handle UX.
+
+## Prerequisites
+
+- `gh` CLI must be authenticated (`gh auth status`)
+- `.github/registry.json` must exist (created during genesis bootstrap)
+- The target package repo must have a `.github/registry.json` following the Genesis registry format
+
+## What is a Genesis Package
+
+A Genesis package is any GitHub repository that contains a `.github/registry.json` declaring extensions and/or skills. Package authors add the `genesis-package` topic to their repo for discoverability.
+
+Packages are referenced as `owner/repo` (e.g. `someuser/cool-extensions`). An optional `@ref` pins to a specific tag or branch (e.g. `someuser/cool-extensions@v1.0.0`).
+
+## Natural Language Triggers
+
+- "install the weather extension from someuser/cool-extensions"
+- "install package from someuser/cool-extensions@v1.0.0"
+- "what packages are installed?"
+- "remove the someuser/cool-extensions package"
+- "check for updates from someuser/cool-extensions"
+- "what's available in someuser/cool-extensions?"
+
+## Commands
+
+### Search — browse what a package offers
+
+```bash
+node .github/skills/packages/packages.js search someuser/cool-extensions
+node .github/skills/packages/packages.js search someuser/cool-extensions@v1.0.0
+```
+
+Output JSON:
+
+```json
+{
+  "source": "someuser/cool-extensions",
+  "ref": "main",
+  "version": "0.3.0",
+  "extensions": [
+    {"name": "weather", "version": "0.1.0", "description": "Weather data lookups"}
+  ],
+  "skills": []
+}
+```
+
+Present this as a readable list. Ask the user which items they want to install.
+
+### Install — add items from a package
+
+```bash
+node .github/skills/packages/packages.js install someuser/cool-extensions
+node .github/skills/packages/packages.js install someuser/cool-extensions@v1.0.0
+node .github/skills/packages/packages.js install someuser/cool-extensions --ref v1.0.0
+node .github/skills/packages/packages.js install someuser/cool-extensions --items weather,forecast
+```
+
+This:
+- Fetches the remote `.github/registry.json`
+- Downloads files for each requested item (all items if `--items` not specified)
+- Runs `npm install --production` if `package.json` exists in an item's directory
+- Updates `.github/registry.json`: adds to `packages[]` array AND merges into top-level `extensions`/`skills` with a `package` field
+
+Output JSON:
+
+```json
+{
+  "source": "someuser/cool-extensions",
+  "ref": "main",
+  "installed": [{"name": "weather", "type": "extension", "version": "0.1.0", "files": 3, "npmInstalled": false}],
+  "updated": [],
+  "skipped": [],
+  "errors": [],
+  "registryUpdated": true
+}
+```
+
+Items in `skipped` have a `reason` — typically a conflict with an existing extension or skill. Always report skipped items to the user.
+
+### Remove — uninstall items from a package
+
+```bash
+node .github/skills/packages/packages.js remove someuser/cool-extensions
+node .github/skills/packages/packages.js remove someuser/cool-extensions --items weather
+```
+
+This:
+- Removes files from disk (staged removal for safety)
+- Cleans up registry entries from both `packages[]` and top-level `extensions`/`skills`
+- If all items from a package are removed, removes the package entry entirely
+
+Output JSON:
+
+```json
+{
+  "source": "someuser/cool-extensions",
+  "removed": [{"name": "weather", "type": "extension", "version": "0.1.0", "path": ".github/extensions/weather"}],
+  "errors": [],
+  "registryUpdated": true
+}
+```
+
+### List — show all installed packages
+
+```bash
+node .github/skills/packages/packages.js list
+```
+
+Output JSON (array):
+
+```json
+[
+  {
+    "source": "someuser/cool-extensions",
+    "ref": "v1.0.0",
+    "extensions": [{"name": "weather", "version": "0.1.0", "description": "Weather data lookups"}],
+    "skills": []
+  }
+]
+```
+
+Present as a readable summary. If the array is empty, say "No third-party packages installed."
+
+### Check — compare installed vs remote versions
+
+```bash
+node .github/skills/packages/packages.js check someuser/cool-extensions
+node .github/skills/packages/packages.js check someuser/cool-extensions --ref v2.0.0
+```
+
+Output JSON:
+
+```json
+{
+  "source": "someuser/cool-extensions",
+  "ref": "main",
+  "remoteVersion": "0.4.0",
+  "updates": [
+    {"name": "weather", "type": "extension", "localVersion": "0.1.0", "remoteVersion": "0.2.0", "status": "update_available"}
+  ],
+  "new": [],
+  "current": [],
+  "notInstalled": false
+}
+```
+
+Status values:
+- `update_available` — newer version exists on remote
+- `removed_upstream` — item no longer exists on remote
+
+If `notInstalled` is true, the package has never been installed — all remote items appear in `new`.
+
+Present as a readable summary with available updates highlighted. If updates exist, ask the user if they want to install them using `install --items name1,name2`.
+
+## Presenting Results
+
+### After install
+
+```
+═══════════════════════════════════════════
+  ✅ PACKAGE INSTALLED
+  Source: someuser/cool-extensions@main
+═══════════════════════════════════════════
+
+Installed:
+  📦 weather v0.1.0 — 3 files
+
+Registry updated.
+```
+
+If there were skipped items:
+```
+⚠️  Skipped (conflict):
+  weather — extension "weather" already exists (origin: ianphil/genesis)
+```
+
+If extensions were installed, remind the user:
+> "New extensions installed. Restart your Copilot session to activate them."
+
+### After remove
+
+```
+Removed:
+  🗑️ weather v0.1.0 — directory deleted
+```
+
+### After list (with packages)
+
+```
+Installed packages:
+
+  someuser/cool-extensions @ v1.0.0
+    📦 weather v0.1.0 — Weather data lookups
+```
+
+### After check (with updates)
+
+```
+Updates available from someuser/cool-extensions:
+  ⬆️ weather v0.1.0 → v0.2.0
+```
+
+## Rules
+
+- **Always confirm before removing** — removals delete directories from disk
+- **Never silently overwrite** — if a conflict is detected, report it and skip the item
+- **Template items are authoritative** — packages cannot overwrite extensions or skills from the genesis template source
+- **Always show search results before installing** — let the user see what's available and select items
+- **Conflict = skip, not fail** — a conflict on one item doesn't block other items from installing
+- **If `gh` CLI is not available**, report the error and stop
+- **If the script fails**, show the error output and suggest checking `gh auth status`

--- a/.github/skills/packages/packages.js
+++ b/.github/skills/packages/packages.js
@@ -1,0 +1,688 @@
+#!/usr/bin/env node
+// packages.js — Install extensions and skills from third-party Genesis packages.
+// Zero dependencies. Requires: Node.js 18+, gh CLI authenticated.
+//
+// Usage:
+//   node packages.js search <owner/repo[@ref]>               — list available items
+//   node packages.js install <owner/repo[@ref]> [--ref <r>] [--items a,b] — install items
+//   node packages.js remove <owner/repo> [--items a,b]       — remove installed items
+//   node packages.js list                                     — list all installed packages
+//   node packages.js check <owner/repo[@ref]> [--ref <r>]    — compare installed vs remote
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function gh(apiPath) {
+  const raw = execSync(`gh api ${apiPath}`, {
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return JSON.parse(raw);
+}
+
+function ghBlob(owner, repo, sha) {
+  const blob = gh(`/repos/${owner}/${repo}/git/blobs/${sha}`);
+  return Buffer.from(blob.content, "base64");
+}
+
+function compareSemver(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return 1;
+    if ((pa[i] || 0) < (pb[i] || 0)) return -1;
+  }
+  return 0;
+}
+
+function findRepoRoot() {
+  let dir = process.cwd();
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, ".github", "registry.json"))) return dir;
+    dir = path.dirname(dir);
+  }
+  return process.cwd();
+}
+
+function readLocalRegistry(root) {
+  const p = path.join(root, ".github", "registry.json");
+  if (!fs.existsSync(p)) {
+    return { version: "0.0.0", source: "", extensions: {}, skills: {}, packages: [] };
+  }
+  const reg = JSON.parse(fs.readFileSync(p, "utf8"));
+  if (!Array.isArray(reg.packages)) reg.packages = [];
+  return reg;
+}
+
+function writeLocalRegistry(root, registry) {
+  const p = path.join(root, ".github", "registry.json");
+  fs.writeFileSync(p, JSON.stringify(registry, null, 2) + "\n", "utf8");
+}
+
+function makeStagedRemovalPath(itemDir) {
+  const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return path.join(
+    path.dirname(itemDir),
+    `${path.basename(itemDir)}.remove-${suffix}`
+  );
+}
+
+// ── Pure logic (testable) ────────────────────────────────────────────────────
+
+// Parse "owner/repo" or "owner/repo@ref" into { owner, repo, ref }
+function parsePackageSource(source) {
+  const atIdx = source.indexOf("@");
+  let repoStr = source;
+  let ref = null;
+
+  if (atIdx !== -1) {
+    repoStr = source.slice(0, atIdx);
+    ref = source.slice(atIdx + 1);
+  }
+
+  const slashIdx = repoStr.indexOf("/");
+  if (slashIdx === -1 || slashIdx === 0 || slashIdx === repoStr.length - 1) {
+    throw new Error(
+      `Invalid package source "${source}". Expected "owner/repo" or "owner/repo@ref".`
+    );
+  }
+
+  return {
+    owner: repoStr.slice(0, slashIdx),
+    repo: repoStr.slice(slashIdx + 1),
+    ref,
+  };
+}
+
+// Find an installed package entry by source (owner/repo), ignoring ref
+function findInstalledPackage(registry, ownerRepo) {
+  return (registry.packages || []).find((p) => p.source === ownerRepo) || null;
+}
+
+// Detect conflicts between items about to be installed and what's already in the registry.
+// Returns an array of conflict descriptions (strings).
+function detectConflicts(registry, itemsByType, packageSource) {
+  const conflicts = [];
+
+  for (const type of ["extensions", "skills"]) {
+    const incoming = itemsByType[type] || {};
+    const existing = registry[type] || {};
+
+    for (const name of Object.keys(incoming)) {
+      if (name in existing) {
+        const origin = existing[name].package || registry.source || "template";
+        if (origin !== packageSource) {
+          conflicts.push(
+            `${type.slice(0, -1)} "${name}" already exists (origin: ${origin})`
+          );
+        }
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+// Merge package items into top-level registry extensions/skills with a `package` field
+function mergeIntoTopLevel(registry, packageSource, installedByType) {
+  for (const type of ["extensions", "skills"]) {
+    if (!registry[type]) registry[type] = {};
+    for (const [name, info] of Object.entries(installedByType[type] || {})) {
+      registry[type][name] = { ...info, package: packageSource };
+    }
+  }
+}
+
+// Remove package items from top-level registry
+function removeFromTopLevel(registry, packageSource, names) {
+  for (const type of ["extensions", "skills"]) {
+    const items = registry[type] || {};
+    for (const name of names) {
+      if (name in items && items[name].package === packageSource) {
+        delete items[name];
+      }
+    }
+  }
+}
+
+// Build the list output for installed packages
+function buildListOutput(registry) {
+  return (registry.packages || []).map((pkg) => ({
+    source: pkg.source,
+    ref: pkg.ref || null,
+    extensions: Object.entries(pkg.installed.extensions || {}).map(
+      ([name, info]) => ({ name, version: info.version, description: info.description })
+    ),
+    skills: Object.entries(pkg.installed.skills || {}).map(
+      ([name, info]) => ({ name, version: info.version, description: info.description })
+    ),
+  }));
+}
+
+// ── Search command ────────────────────────────────────────────────────────────
+
+function search(rawSource) {
+  const { owner, repo, ref: parsedRef } = parsePackageSource(rawSource);
+  const ref = parsedRef || "main";
+
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${ref}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        error: `Failed to fetch registry from ${owner}/${repo}@${ref}: ${e.message.slice(0, 200)}`,
+      })
+    );
+    process.exit(1);
+  }
+
+  const result = {
+    source: `${owner}/${repo}`,
+    ref,
+    version: remote.version,
+    extensions: Object.entries(remote.extensions || {}).map(([name, info]) => ({
+      name,
+      version: info.version,
+      description: info.description,
+    })),
+    skills: Object.entries(remote.skills || {}).map(([name, info]) => ({
+      name,
+      version: info.version,
+      description: info.description,
+    })),
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ── Install command ───────────────────────────────────────────────────────────
+
+function install(rawSource, opts) {
+  const { owner, repo, ref: parsedRef } = parsePackageSource(rawSource);
+  const ref = opts.ref || parsedRef || "main";
+  const requestedItems = opts.items ? new Set(opts.items) : null;
+
+  const root = opts.root || findRepoRoot();
+  const local = readLocalRegistry(root);
+  const ownerRepo = `${owner}/${repo}`;
+
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${ref}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        error: `Failed to fetch registry from ${ownerRepo}@${ref}: ${e.message.slice(0, 200)}`,
+      })
+    );
+    process.exit(1);
+  }
+
+  // Collect the items to install
+  const toInstallByType = { extensions: {}, skills: {} };
+  const allRemoteNames = new Set();
+  for (const type of ["extensions", "skills"]) {
+    for (const [name, info] of Object.entries(remote[type] || {})) {
+      allRemoteNames.add(name);
+      if (requestedItems === null || requestedItems.has(name)) {
+        toInstallByType[type][name] = info;
+      }
+    }
+  }
+
+  // Conflict detection — skip items that already exist from a different origin
+  const conflicts = detectConflicts(local, toInstallByType, ownerRepo);
+  const conflictNames = new Set(
+    conflicts.map((c) => c.match(/"([^"]+)"/)?.[1]).filter(Boolean)
+  );
+
+  const result = {
+    source: ownerRepo,
+    ref,
+    installed: [],
+    updated: [],
+    skipped: [],
+    errors: [],
+    registryUpdated: false,
+  };
+
+  // Report unknown requested items
+  if (requestedItems) {
+    for (const name of requestedItems) {
+      if (!allRemoteNames.has(name)) {
+        result.errors.push({ name, error: `Item "${name}" not found in ${ownerRepo}@${ref}` });
+      }
+    }
+  }
+
+  // Report conflicts as skipped
+  for (const conflict of conflicts) {
+    const name = conflict.match(/"([^"]+)"/)?.[1] || "unknown";
+    result.skipped.push({ name, reason: conflict });
+  }
+
+  // Fetch tree once for file downloads
+  let treeMap = new Map();
+  if (Object.values(toInstallByType).some((t) => Object.keys(t).length > 0)) {
+    try {
+      const tree = gh(`/repos/${owner}/${repo}/git/trees/${ref}?recursive=1`);
+      for (const entry of tree.tree) {
+        if (entry.type === "blob") {
+          treeMap.set(entry.path, entry.sha);
+        }
+      }
+    } catch (e) {
+      console.error(
+        JSON.stringify({
+          error: `Failed to fetch file tree from ${ownerRepo}@${ref}: ${e.message.slice(0, 200)}`,
+        })
+      );
+      process.exit(1);
+    }
+  }
+
+  // Find or create the package entry in registry
+  let pkgEntry = findInstalledPackage(local, ownerRepo);
+  if (!pkgEntry) {
+    pkgEntry = { source: ownerRepo, ref, installed: { extensions: {}, skills: {} } };
+    local.packages.push(pkgEntry);
+  } else {
+    // Update ref if it changed
+    pkgEntry.ref = ref;
+  }
+
+  for (const type of ["extensions", "skills"]) {
+    for (const [name, info] of Object.entries(toInstallByType[type])) {
+      if (conflictNames.has(name)) continue;
+
+      const isUpdate = name in (pkgEntry.installed[type] || {});
+      const itemPath = info.path;
+
+      try {
+        const prefix = itemPath.endsWith("/") ? itemPath : itemPath + "/";
+        const files = [];
+        for (const [filePath, sha] of treeMap) {
+          if (filePath.startsWith(prefix) || filePath === itemPath) {
+            files.push({ path: filePath, sha });
+          }
+        }
+
+        if (files.length === 0) {
+          result.errors.push({ name, error: `No files found in tree under ${itemPath}` });
+          continue;
+        }
+
+        let fileCount = 0;
+        for (const file of files) {
+          const content = ghBlob(owner, repo, file.sha);
+          const localPath = path.join(root, file.path);
+          fs.mkdirSync(path.dirname(localPath), { recursive: true });
+          fs.writeFileSync(localPath, content);
+          fileCount++;
+        }
+
+        let npmInstalled = false;
+        const pkgJsonPath = path.join(root, itemPath, "package.json");
+        if (fs.existsSync(pkgJsonPath)) {
+          try {
+            execSync("npm install --omit=dev", {
+              cwd: path.join(root, itemPath),
+              encoding: "utf8",
+              stdio: "pipe",
+              timeout: 120000,
+            });
+            npmInstalled = true;
+          } catch (e) {
+            result.errors.push({
+              name,
+              error: `npm install failed: ${e.message.slice(0, 200)}`,
+            });
+          }
+        }
+
+        const itemMeta = { version: info.version, path: info.path, description: info.description };
+
+        // Update package entry
+        if (!pkgEntry.installed[type]) pkgEntry.installed[type] = {};
+        pkgEntry.installed[type][name] = itemMeta;
+
+        const entry = {
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+          files: fileCount,
+          npmInstalled,
+        };
+
+        if (isUpdate) {
+          result.updated.push(entry);
+        } else {
+          result.installed.push(entry);
+        }
+      } catch (e) {
+        result.errors.push({ name, error: e.message.slice(0, 300) });
+      }
+    }
+  }
+
+  if (result.installed.length > 0 || result.updated.length > 0) {
+    // Merge into top-level registry
+    mergeIntoTopLevel(local, ownerRepo, pkgEntry.installed);
+    writeLocalRegistry(root, local);
+    result.registryUpdated = true;
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ── Remove command ────────────────────────────────────────────────────────────
+
+function remove(rawSource, opts) {
+  const { owner, repo } = parsePackageSource(rawSource);
+  const ownerRepo = `${owner}/${repo}`;
+  const root = (opts && opts.root) || findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  const pkgEntry = findInstalledPackage(local, ownerRepo);
+
+  const result = {
+    source: ownerRepo,
+    removed: [],
+    errors: [],
+    registryUpdated: false,
+  };
+
+  if (!pkgEntry) {
+    result.errors.push({ name: ownerRepo, error: "Package not found in local registry" });
+    return result;
+  }
+
+  // Determine which item names to remove
+  const requestedItems = (opts && opts.items)
+    ? new Set(opts.items)
+    : new Set([
+        ...Object.keys(pkgEntry.installed.extensions || {}),
+        ...Object.keys(pkgEntry.installed.skills || {}),
+      ]);
+
+  const pendingRemovals = [];
+
+  for (const type of ["extensions", "skills"]) {
+    for (const name of Array.from(requestedItems)) {
+      const items = pkgEntry.installed[type] || {};
+      if (!(name in items)) continue;
+
+      const info = items[name];
+      const itemDir = path.join(root, info.path);
+      let stagedDir = null;
+
+      try {
+        if (fs.existsSync(itemDir)) {
+          stagedDir = makeStagedRemovalPath(itemDir);
+          fs.renameSync(itemDir, stagedDir);
+        }
+
+        delete pkgEntry.installed[type][name];
+        pendingRemovals.push({ name, info, type, itemDir, stagedDir });
+      } catch (e) {
+        if (stagedDir && fs.existsSync(stagedDir)) {
+          fs.renameSync(stagedDir, itemDir);
+        }
+        result.errors.push({ name, error: e.message.slice(0, 300) });
+      }
+    }
+  }
+
+  if (pendingRemovals.length > 0) {
+    try {
+      // Remove from top-level registry
+      const removedNames = pendingRemovals.map((r) => r.name);
+      removeFromTopLevel(local, ownerRepo, removedNames);
+
+      // Remove the entire package entry if no items remain
+      const remainingExt = Object.keys(pkgEntry.installed.extensions || {}).length;
+      const remainingSkills = Object.keys(pkgEntry.installed.skills || {}).length;
+      if (remainingExt + remainingSkills === 0) {
+        local.packages = local.packages.filter((p) => p.source !== ownerRepo);
+      }
+
+      writeLocalRegistry(root, local);
+      result.registryUpdated = true;
+
+      for (const item of pendingRemovals) {
+        if (item.stagedDir && fs.existsSync(item.stagedDir)) {
+          fs.rmSync(item.stagedDir, { recursive: true, force: true });
+        }
+        result.removed.push({
+          name: item.name,
+          type: item.type === "extensions" ? "extension" : "skill",
+          version: item.info.version,
+          path: item.info.path,
+        });
+      }
+    } catch (e) {
+      // Rollback
+      for (let i = pendingRemovals.length - 1; i >= 0; i--) {
+        const item = pendingRemovals[i];
+        pkgEntry.installed[item.type][item.name] = item.info;
+        if (item.stagedDir && fs.existsSync(item.stagedDir)) {
+          fs.renameSync(item.stagedDir, item.itemDir);
+        }
+        result.errors.push({
+          name: item.name,
+          error: `Failed to update registry: ${e.message.slice(0, 300)}`,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+// ── List command ──────────────────────────────────────────────────────────────
+
+function list(opts) {
+  const root = (opts && opts.root) || findRepoRoot();
+  const local = readLocalRegistry(root);
+  return buildListOutput(local);
+}
+
+// ── Check command ─────────────────────────────────────────────────────────────
+
+function check(rawSource, opts) {
+  const { owner, repo, ref: parsedRef } = parsePackageSource(rawSource);
+  const ref = (opts && opts.ref) || parsedRef || "main";
+  const ownerRepo = `${owner}/${repo}`;
+
+  const root = (opts && opts.root) || findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  const pkgEntry = findInstalledPackage(local, ownerRepo);
+
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${ref}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        error: `Failed to fetch registry from ${ownerRepo}@${ref}: ${e.message.slice(0, 200)}`,
+      })
+    );
+    process.exit(1);
+  }
+
+  const result = {
+    source: ownerRepo,
+    ref,
+    remoteVersion: remote.version,
+    updates: [],
+    new: [],
+    current: [],
+    notInstalled: !pkgEntry,
+  };
+
+  if (!pkgEntry) {
+    // Nothing installed yet — all remote items are "new"
+    for (const type of ["extensions", "skills"]) {
+      for (const [name, info] of Object.entries(remote[type] || {})) {
+        result.new.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+          description: info.description,
+        });
+      }
+    }
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  for (const type of ["extensions", "skills"]) {
+    const remoteItems = remote[type] || {};
+    const installedItems = pkgEntry.installed[type] || {};
+
+    for (const [name, info] of Object.entries(installedItems)) {
+      const remoteItem = remoteItems[name];
+      if (!remoteItem) {
+        result.updates.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          localVersion: info.version,
+          status: "removed_upstream",
+        });
+      } else if (compareSemver(remoteItem.version, info.version) > 0) {
+        result.updates.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          localVersion: info.version,
+          remoteVersion: remoteItem.version,
+          status: "update_available",
+        });
+      } else {
+        result.current.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+        });
+      }
+    }
+
+    for (const [name, info] of Object.entries(remoteItems)) {
+      if (!(name in installedItems)) {
+        result.new.push({
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+          description: info.description,
+        });
+      }
+    }
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ── Exports (for testing) ────────────────────────────────────────────────────
+
+module.exports = {
+  parsePackageSource,
+  detectConflicts,
+  mergeIntoTopLevel,
+  removeFromTopLevel,
+  buildListOutput,
+  findInstalledPackage,
+  compareSemver,
+  remove,
+  list,
+};
+
+// ── CLI entry ─────────────────────────────────────────────────────────────────
+
+if (require.main === module) {
+  const [, , command, ...args] = process.argv;
+
+  function parseFlags(flagArgs) {
+    const flags = { items: null, ref: null };
+    const positional = [];
+    for (let i = 0; i < flagArgs.length; i++) {
+      if (flagArgs[i] === "--ref" && flagArgs[i + 1]) {
+        flags.ref = flagArgs[++i];
+      } else if (flagArgs[i] === "--items" && flagArgs[i + 1]) {
+        flags.items = flagArgs[++i].split(",").map((s) => s.trim());
+      } else if (!flagArgs[i].startsWith("--")) {
+        positional.push(flagArgs[i]);
+      }
+    }
+    if (!flags.items && positional.length > 0) {
+      flags.items = positional;
+    }
+    return flags;
+  }
+
+  switch (command) {
+    case "search": {
+      if (!args[0]) {
+        console.error(JSON.stringify({ error: "Usage: node packages.js search <owner/repo[@ref]>" }));
+        process.exit(1);
+      }
+      search(args[0]);
+      break;
+    }
+    case "install": {
+      if (!args[0]) {
+        console.error(JSON.stringify({ error: "Usage: node packages.js install <owner/repo[@ref]> [--ref <ref>] [--items name1,name2]" }));
+        process.exit(1);
+      }
+      const { ref, items } = parseFlags(args.slice(1));
+      install(args[0], { ref, items });
+      break;
+    }
+    case "remove": {
+      if (!args[0]) {
+        console.error(JSON.stringify({ error: "Usage: node packages.js remove <owner/repo> [--items name1,name2]" }));
+        process.exit(1);
+      }
+      const { items } = parseFlags(args.slice(1));
+      console.log(JSON.stringify(remove(args[0], { items }), null, 2));
+      break;
+    }
+    case "list": {
+      console.log(JSON.stringify(list(), null, 2));
+      break;
+    }
+    case "check": {
+      if (!args[0]) {
+        console.error(JSON.stringify({ error: "Usage: node packages.js check <owner/repo[@ref]> [--ref <ref>]" }));
+        process.exit(1);
+      }
+      const { ref } = parseFlags(args.slice(1));
+      check(args[0], { ref });
+      break;
+    }
+    default: {
+      console.error(JSON.stringify({
+        error: `Unknown command: ${command}. Use "search", "install", "remove", "list", or "check".`,
+      }));
+      process.exit(1);
+    }
+  }
+}

--- a/.github/skills/packages/packages.test.js
+++ b/.github/skills/packages/packages.test.js
@@ -1,0 +1,560 @@
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const {
+  parsePackageSource,
+  detectConflicts,
+  mergeIntoTopLevel,
+  removeFromTopLevel,
+  buildListOutput,
+  findInstalledPackage,
+  compareSemver,
+  remove,
+  list,
+} = require("./packages.js");
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeTempRepo(registry, dirs = []) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "packages-test-"));
+  const ghDir = path.join(root, ".github");
+  fs.mkdirSync(ghDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(ghDir, "registry.json"),
+    JSON.stringify(registry, null, 2),
+    "utf8"
+  );
+  for (const dir of dirs) {
+    const full = path.join(root, dir);
+    fs.mkdirSync(full, { recursive: true });
+    fs.writeFileSync(path.join(full, "index.js"), "// stub", "utf8");
+  }
+  return root;
+}
+
+function readRegistry(root) {
+  return JSON.parse(
+    fs.readFileSync(path.join(root, ".github", "registry.json"), "utf8")
+  );
+}
+
+function makeBaseRegistry(overrides = {}) {
+  return {
+    version: "0.14.0",
+    source: "ianphil/genesis",
+    channel: "main",
+    extensions: {},
+    skills: {},
+    packages: [],
+    ...overrides,
+  };
+}
+
+// ── parsePackageSource ────────────────────────────────────────────────────────
+
+describe("parsePackageSource", () => {
+  it("parses owner/repo without ref", () => {
+    const result = parsePackageSource("someuser/cool-extensions");
+    assert.equal(result.owner, "someuser");
+    assert.equal(result.repo, "cool-extensions");
+    assert.equal(result.ref, null);
+  });
+
+  it("parses owner/repo@ref", () => {
+    const result = parsePackageSource("someuser/cool-extensions@v1.0.0");
+    assert.equal(result.owner, "someuser");
+    assert.equal(result.repo, "cool-extensions");
+    assert.equal(result.ref, "v1.0.0");
+  });
+
+  it("parses owner/repo@branch-name", () => {
+    const result = parsePackageSource("org/repo@feature/my-branch");
+    assert.equal(result.owner, "org");
+    assert.equal(result.repo, "repo");
+    assert.equal(result.ref, "feature/my-branch");
+  });
+
+  it("throws on missing slash", () => {
+    assert.throws(
+      () => parsePackageSource("nodash"),
+      /Invalid package source/
+    );
+  });
+
+  it("throws on leading slash", () => {
+    assert.throws(
+      () => parsePackageSource("/repo"),
+      /Invalid package source/
+    );
+  });
+
+  it("throws on trailing slash", () => {
+    assert.throws(
+      () => parsePackageSource("owner/"),
+      /Invalid package source/
+    );
+  });
+
+  it("handles org with hyphens and dots", () => {
+    const result = parsePackageSource("my-org/my.repo@v2.3.4");
+    assert.equal(result.owner, "my-org");
+    assert.equal(result.repo, "my.repo");
+    assert.equal(result.ref, "v2.3.4");
+  });
+});
+
+// ── compareSemver ─────────────────────────────────────────────────────────────
+
+describe("compareSemver", () => {
+  it("returns 0 for equal versions", () => {
+    assert.equal(compareSemver("1.0.0", "1.0.0"), 0);
+  });
+
+  it("returns 1 when a > b (major)", () => {
+    assert.equal(compareSemver("2.0.0", "1.9.9"), 1);
+  });
+
+  it("returns -1 when a < b (minor)", () => {
+    assert.equal(compareSemver("1.0.0", "1.1.0"), -1);
+  });
+
+  it("returns 1 when a > b (patch)", () => {
+    assert.equal(compareSemver("1.0.2", "1.0.1"), 1);
+  });
+
+  it("handles missing patch as 0", () => {
+    assert.equal(compareSemver("1.0", "1.0.0"), 0);
+  });
+});
+
+// ── findInstalledPackage ──────────────────────────────────────────────────────
+
+describe("findInstalledPackage", () => {
+  it("returns null when packages array is empty", () => {
+    const registry = makeBaseRegistry();
+    assert.equal(findInstalledPackage(registry, "someuser/pkg"), null);
+  });
+
+  it("returns null when package is not found", () => {
+    const registry = makeBaseRegistry({
+      packages: [{ source: "other/pkg", ref: null, installed: { extensions: {}, skills: {} } }],
+    });
+    assert.equal(findInstalledPackage(registry, "someuser/pkg"), null);
+  });
+
+  it("returns the matching package entry", () => {
+    const pkg = { source: "someuser/pkg", ref: "v1.0.0", installed: { extensions: {}, skills: {} } };
+    const registry = makeBaseRegistry({ packages: [pkg] });
+    assert.deepEqual(findInstalledPackage(registry, "someuser/pkg"), pkg);
+  });
+
+  it("matches by source only, ignoring ref", () => {
+    const pkg = { source: "someuser/pkg", ref: "v1.0.0", installed: { extensions: {}, skills: {} } };
+    const registry = makeBaseRegistry({ packages: [pkg] });
+    // Same source regardless of ref
+    assert.deepEqual(findInstalledPackage(registry, "someuser/pkg"), pkg);
+  });
+});
+
+// ── detectConflicts ───────────────────────────────────────────────────────────
+
+describe("detectConflicts", () => {
+  it("returns empty array when no conflicts", () => {
+    const registry = makeBaseRegistry({
+      extensions: { cron: { version: "0.1.0", path: ".github/extensions/cron" } },
+    });
+    const incoming = { extensions: { weather: { version: "0.1.0" } }, skills: {} };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 0);
+  });
+
+  it("detects conflict when template extension already exists", () => {
+    const registry = makeBaseRegistry({
+      extensions: { cron: { version: "0.1.0", path: ".github/extensions/cron" } },
+    });
+    const incoming = { extensions: { cron: { version: "0.2.0" } }, skills: {} };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 1);
+    assert.ok(conflicts[0].includes('"cron"'));
+    assert.ok(conflicts[0].includes("ianphil/genesis"));
+  });
+
+  it("detects conflict when another package already installed the same item", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "firstuser/pkg" },
+      },
+    });
+    const incoming = { extensions: { weather: { version: "0.2.0" } }, skills: {} };
+    const conflicts = detectConflicts(registry, incoming, "seconduser/other-pkg");
+    assert.equal(conflicts.length, 1);
+    assert.ok(conflicts[0].includes("firstuser/pkg"));
+  });
+
+  it("no conflict when updating an item from the same package", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "someuser/pkg" },
+      },
+    });
+    const incoming = { extensions: { weather: { version: "0.2.0" } }, skills: {} };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 0);
+  });
+
+  it("detects conflicts in skills too", () => {
+    const registry = makeBaseRegistry({
+      skills: { "daily-report": { version: "0.1.0", path: ".github/skills/daily-report" } },
+    });
+    const incoming = {
+      extensions: {},
+      skills: { "daily-report": { version: "0.2.0" } },
+    };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 1);
+    assert.ok(conflicts[0].includes('"daily-report"'));
+  });
+
+  it("detects multiple conflicts across types", () => {
+    const registry = makeBaseRegistry({
+      extensions: { cron: { version: "0.1.0", path: ".github/extensions/cron" } },
+      skills: { commit: { version: "0.1.0", path: ".github/skills/commit" } },
+    });
+    const incoming = {
+      extensions: { cron: { version: "0.2.0" } },
+      skills: { commit: { version: "0.2.0" } },
+    };
+    const conflicts = detectConflicts(registry, incoming, "someuser/pkg");
+    assert.equal(conflicts.length, 2);
+  });
+});
+
+// ── mergeIntoTopLevel ─────────────────────────────────────────────────────────
+
+describe("mergeIntoTopLevel", () => {
+  it("adds extensions with package field", () => {
+    const registry = makeBaseRegistry();
+    const installed = {
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+      },
+      skills: {},
+    };
+    mergeIntoTopLevel(registry, "someuser/pkg", installed);
+    assert.ok("weather" in registry.extensions);
+    assert.equal(registry.extensions.weather.package, "someuser/pkg");
+    assert.equal(registry.extensions.weather.version, "0.1.0");
+  });
+
+  it("adds skills with package field", () => {
+    const registry = makeBaseRegistry();
+    const installed = {
+      extensions: {},
+      skills: {
+        "my-skill": { version: "0.2.0", path: ".github/skills/my-skill", description: "Skill" },
+      },
+    };
+    mergeIntoTopLevel(registry, "someuser/pkg", installed);
+    assert.ok("my-skill" in registry.skills);
+    assert.equal(registry.skills["my-skill"].package, "someuser/pkg");
+  });
+
+  it("does not touch existing template items", () => {
+    const registry = makeBaseRegistry({
+      extensions: { cron: { version: "0.1.4", path: ".github/extensions/cron" } },
+    });
+    const installed = {
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+      },
+      skills: {},
+    };
+    mergeIntoTopLevel(registry, "someuser/pkg", installed);
+    assert.ok(!registry.extensions.cron.package);
+    assert.equal(registry.extensions.cron.version, "0.1.4");
+  });
+});
+
+// ── removeFromTopLevel ────────────────────────────────────────────────────────
+
+describe("removeFromTopLevel", () => {
+  it("removes extension owned by the package", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", package: "someuser/pkg" },
+        cron: { version: "0.1.4" },
+      },
+    });
+    removeFromTopLevel(registry, "someuser/pkg", ["weather"]);
+    assert.ok(!("weather" in registry.extensions));
+    assert.ok("cron" in registry.extensions);
+  });
+
+  it("does not remove items owned by other packages or template", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", package: "someuser/pkg" },
+        snow: { version: "0.1.0", package: "other/pkg" },
+        cron: { version: "0.1.4" },
+      },
+    });
+    removeFromTopLevel(registry, "someuser/pkg", ["weather", "snow", "cron"]);
+    assert.ok(!("weather" in registry.extensions));
+    assert.ok("snow" in registry.extensions);
+    assert.ok("cron" in registry.extensions);
+  });
+
+  it("removes skill owned by the package", () => {
+    const registry = makeBaseRegistry({
+      skills: {
+        "my-skill": { version: "0.1.0", package: "someuser/pkg" },
+      },
+    });
+    removeFromTopLevel(registry, "someuser/pkg", ["my-skill"]);
+    assert.ok(!("my-skill" in registry.skills));
+  });
+});
+
+// ── buildListOutput ───────────────────────────────────────────────────────────
+
+describe("buildListOutput", () => {
+  it("returns empty array when no packages", () => {
+    const registry = makeBaseRegistry();
+    assert.deepEqual(buildListOutput(registry), []);
+  });
+
+  it("returns empty array when packages key is missing", () => {
+    const registry = { version: "0.13.0", source: "ianphil/genesis", extensions: {}, skills: {} };
+    assert.deepEqual(buildListOutput(registry), []);
+  });
+
+  it("formats a package with extensions and skills", () => {
+    const registry = makeBaseRegistry({
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: "v1.0.0",
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", description: "Weather lookups" },
+            },
+            skills: {
+              "weather-query": { version: "0.1.0", description: "Ask about weather" },
+            },
+          },
+        },
+      ],
+    });
+    const result = buildListOutput(registry);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].source, "someuser/pkg");
+    assert.equal(result[0].ref, "v1.0.0");
+    assert.equal(result[0].extensions.length, 1);
+    assert.equal(result[0].extensions[0].name, "weather");
+    assert.equal(result[0].skills.length, 1);
+    assert.equal(result[0].skills[0].name, "weather-query");
+  });
+
+  it("sets ref to null when not present", () => {
+    const registry = makeBaseRegistry({
+      packages: [
+        {
+          source: "someuser/pkg",
+          installed: { extensions: {}, skills: {} },
+        },
+      ],
+    });
+    const result = buildListOutput(registry);
+    assert.equal(result[0].ref, null);
+  });
+
+  it("lists multiple packages", () => {
+    const registry = makeBaseRegistry({
+      packages: [
+        { source: "user/pkg1", ref: null, installed: { extensions: {}, skills: {} } },
+        { source: "user/pkg2", ref: "v2.0.0", installed: { extensions: {}, skills: {} } },
+      ],
+    });
+    const result = buildListOutput(registry);
+    assert.equal(result.length, 2);
+    assert.equal(result[0].source, "user/pkg1");
+    assert.equal(result[1].source, "user/pkg2");
+  });
+});
+
+// ── remove (filesystem) ───────────────────────────────────────────────────────
+
+describe("remove — filesystem", () => {
+  let root;
+
+  afterEach(() => {
+    if (root && fs.existsSync(root)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error when package is not installed", () => {
+    root = makeTempRepo(makeBaseRegistry());
+    const result = remove("someuser/pkg", { root });
+    assert.equal(result.errors.length, 1);
+    assert.ok(result.errors[0].error.includes("not found"));
+    assert.equal(result.removed.length, 0);
+    assert.equal(result.registryUpdated, false);
+  });
+
+  it("removes an installed extension and updates registry", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "someuser/pkg" },
+      },
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: null,
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+            },
+            skills: {},
+          },
+        },
+      ],
+    });
+    root = makeTempRepo(registry, [".github/extensions/weather"]);
+
+    const result = remove("someuser/pkg", { root });
+
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.removed.length, 1);
+    assert.equal(result.removed[0].name, "weather");
+    assert.equal(result.registryUpdated, true);
+
+    // Directory should be gone
+    assert.ok(!fs.existsSync(path.join(root, ".github/extensions/weather")));
+
+    // Registry should be cleaned up
+    const updated = readRegistry(root);
+    assert.ok(!("weather" in updated.extensions));
+    assert.equal(updated.packages.length, 0);
+  });
+
+  it("removes a specific item when --items is specified", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "someuser/pkg" },
+        forecast: { version: "0.1.0", path: ".github/extensions/forecast", package: "someuser/pkg" },
+      },
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: null,
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+              forecast: { version: "0.1.0", path: ".github/extensions/forecast", description: "Forecast" },
+            },
+            skills: {},
+          },
+        },
+      ],
+    });
+    root = makeTempRepo(registry, [
+      ".github/extensions/weather",
+      ".github/extensions/forecast",
+    ]);
+
+    const result = remove("someuser/pkg", { root, items: ["weather"] });
+
+    assert.equal(result.removed.length, 1);
+    assert.equal(result.removed[0].name, "weather");
+
+    // forecast should still be there
+    assert.ok(fs.existsSync(path.join(root, ".github/extensions/forecast")));
+
+    // Package entry should remain (still has forecast)
+    const updated = readRegistry(root);
+    assert.equal(updated.packages.length, 1);
+    assert.ok("forecast" in updated.packages[0].installed.extensions);
+    assert.ok(!("weather" in updated.extensions));
+  });
+
+  it("removes package entry entirely when all items are removed", () => {
+    const registry = makeBaseRegistry({
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", package: "someuser/pkg" },
+      },
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: null,
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+            },
+            skills: {},
+          },
+        },
+      ],
+    });
+    root = makeTempRepo(registry, [".github/extensions/weather"]);
+
+    remove("someuser/pkg", { root, items: ["weather"] });
+
+    const updated = readRegistry(root);
+    assert.equal(updated.packages.length, 0);
+  });
+});
+
+// ── list (filesystem) ─────────────────────────────────────────────────────────
+
+describe("list — filesystem", () => {
+  let root;
+
+  afterEach(() => {
+    if (root && fs.existsSync(root)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty array when no packages installed", () => {
+    root = makeTempRepo(makeBaseRegistry());
+    const result = list({ root });
+    assert.deepEqual(result, []);
+  });
+
+  it("returns list of installed packages", () => {
+    const registry = makeBaseRegistry({
+      packages: [
+        {
+          source: "someuser/pkg",
+          ref: "v1.0.0",
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", description: "Weather" },
+            },
+            skills: {},
+          },
+        },
+      ],
+    });
+    root = makeTempRepo(registry);
+    const result = list({ root });
+    assert.equal(result.length, 1);
+    assert.equal(result[0].source, "someuser/pkg");
+    assert.equal(result[0].extensions[0].name, "weather");
+  });
+
+  it("handles registry without packages key gracefully", () => {
+    const registry = {
+      version: "0.13.0",
+      source: "ianphil/genesis",
+      extensions: {},
+      skills: {},
+    };
+    root = makeTempRepo(registry);
+    const result = list({ root });
+    assert.deepEqual(result, []);
+  });
+});

--- a/.github/skills/upgrade/SKILL.md
+++ b/.github/skills/upgrade/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: upgrade
+description: Pull new extensions and skills from the genesis template registry. Use when user asks to "check for updates", "upgrade", "get latest extensions", or "sync from genesis".
+---
+
+# Upgrade from Genesis Registry
+
+Check the genesis template for new or updated extensions and skills, then install them.
+
+**This skill includes `upgrade.js`** — a script that handles all registry comparison, file downloading, and installation deterministically. Your job is to run it and handle UX.
+
+## Prerequisites
+
+- `gh` CLI must be authenticated (`gh auth status`)
+- `.github/registry.json` must exist with a `source` field (e.g. `"source": "ianphil/genesis"`)
+- Optional `"branch"` field in `registry.json` to track a non-main branch (defaults to `"main"`)
+- Optional `"channel"` field in `registry.json` to select a release channel (e.g. `"main"`, `"frontier"`). Takes precedence over `"branch"`. Defaults to `"main"`.
+- If `registry.json` is missing or has no `source`, ask the user for the source repo (default: `ianphil/genesis`) and create it
+
+## Channels
+
+Genesis supports release channels for repos that publish multiple branches. The channel determines which branch's registry is used for `check` and `install`.
+
+### Switch channels
+
+```bash
+node .github/skills/upgrade/upgrade.js channel <name>
+```
+
+This:
+- Sets `"channel": "<name>"` in the local registry
+- Fetches the remote registry from the `<name>` branch
+- Returns a diff showing what items would be added or removed
+
+### Already on target channel
+
+If the agent is already on the requested channel, the output includes `"changed": false` — no action needed.
+
+## Migrate (Channel → Package)
+
+When a release channel is being retired in favor of a package repo, use `migrate` to rewrite the registry:
+
+```bash
+node .github/skills/upgrade/upgrade.js migrate --source ianphil/genesis-frontier
+```
+
+This:
+- Diffs local registry against the target channel's remote (default: `main`)
+- Items not in the template get a `package` field assigned to the `--source`
+- Populates the `packages[]` array with an installed manifest
+- Switches channel to the target (default: `main`)
+- No files move, no downloads — pure registry rewrite
+
+Options:
+- `--source <owner/repo>` (required) — the package repo to assign non-template items to
+- `--channel <name>` (optional, default: `main`) — the target channel to switch to
+
+After migration, `upgrade` pulls from the target channel and non-template items are managed by the packages skill.
+
+## Phase 1: Check for Updates
+
+Run the check command from the repo root:
+
+```bash
+node .github/skills/upgrade/upgrade.js check
+```
+
+This outputs JSON with the diff:
+
+```json
+{
+  "source": "ianphil/genesis",
+  "remoteVersion": "0.8.0",
+  "localVersion": "0.7.2",
+  "new": [{"name": "foo", "type": "skill", "version": "0.2.0", "description": "..."}],
+  "updated": [{"name": "daily-report", "type": "skill", "version": "0.2.0", "localVersion": "0.1.0", "description": "..."}],
+  "current": [{"name": "commit", "type": "skill", "version": "0.1.0", "description": "..."}],
+  "renamed": [{"oldName": "code-exec", "newName": "bridge", "type": "extension", "version": "0.2.0", "localVersion": "0.1.2", "description": "..."}],
+  "removed": [{"name": "tunnel", "type": "extension", "version": "0.1.0", "description": "..."}],
+  "localOnly": [{"name": "custom-tool", "type": "extension", "version": "0.1.0", "description": "..."}]
+}
+```
+
+## Phase 2: Present Results
+
+Format the JSON into a human-readable summary:
+
+```
+═══════════════════════════════════════════
+  📦 REGISTRY UPDATE CHECK
+  Source: ianphil/genesis (remote v0.8.0)
+  Local: v0.7.2
+═══════════════════════════════════════════
+
+📦 Extensions:
+  🆕 cron v0.3.0 — Scheduled job execution
+  🔄 code-exec → bridge v0.2.0 — renamed
+  🗑️ tunnel v0.1.0 — removed from upstream
+
+📄 Skills:
+  ✅ commit v0.3.0 — up to date
+  ⬆️ daily-report v0.4.0 — update available (local: v0.3.0)
+  🆕 copilot-extension v0.3.0 — SDK reference
+
+📌 Pinned (local only):
+  📌 custom-tool v0.1.0 — kept locally
+
+Install all new/updated/renamed? Remove items deleted upstream? Or pick specific ones.
+```
+
+Use the `ask_user` tool to let the user select what to install and what to remove.
+
+If there are `removed` items, present them separately and explain they were deleted upstream. For each removed item, the user can either:
+- **Accept** — the item will be deleted locally
+- **Decline** — the item will be pinned (`local: true`) and never flagged again
+
+If everything is up to date (`new`, `updated`, and `removed` are all empty), say so and stop.
+
+## Phase 3: Install Selected Items
+
+Run the install command with a comma-separated list of selected item names:
+
+```bash
+node .github/skills/upgrade/upgrade.js install cron,daily-report,copilot-extension
+```
+
+This:
+- Fetches the full file tree from the remote repo (single API call)
+- Downloads and writes every file for each selected item
+- Runs `npm install --production` if a `package.json` exists in the item's path
+- Updates `.github/registry.json` with new versions
+
+Output JSON:
+
+```json
+{
+  "installed": [{"name": "cron", "type": "extension", "version": "0.3.0", "files": 14, "npmInstalled": true}],
+  "updated": [{"name": "daily-report", "type": "skill", "version": "0.4.0", "files": 1, "from": "0.3.0"}],
+  "errors": [],
+  "registryUpdated": true
+}
+```
+
+Items with `renamedFrom` indicate a rename was processed — the old directory was removed and the old registry entry deleted.
+
+## Phase 3b: Remove Selected Items
+
+For items the user accepted for removal, run:
+
+```bash
+node .github/skills/upgrade/upgrade.js remove tunnel,old-skill
+```
+
+This:
+- Looks up each name in the local registry (extensions and skills)
+- Deletes the directory from disk
+- Removes the entry from `.github/registry.json`
+
+Output JSON:
+
+```json
+{
+  "removed": [{"name": "tunnel", "type": "extension", "version": "0.1.0", "path": ".github/extensions/tunnel"}],
+  "errors": [],
+  "registryUpdated": true
+}
+```
+
+## Phase 3c: Pin Declined Removals
+
+For removed items the user chose to **keep**, pin them so they won't be flagged again:
+
+```bash
+node .github/skills/upgrade/upgrade.js pin tunnel
+```
+
+This sets `"local": true` on the item in `.github/registry.json`. Future `check` runs will list it under `localOnly` instead of `removed`.
+
+Output JSON:
+
+```json
+{
+  "pinned": [{"name": "tunnel", "type": "extension", "version": "0.1.0"}],
+  "errors": []
+}
+```
+
+## Phase 4: Summary
+
+Format the install results:
+
+```
+═══════════════════════════════════════════
+  ✅ UPGRADE COMPLETE
+═══════════════════════════════════════════
+
+Installed:
+  📦 cron v0.3.0 — 14 files, npm installed
+  📄 copilot-extension v0.3.0 — 1 file
+
+Updated:
+  📄 daily-report v0.3.0 → v0.4.0 — 1 file
+
+Renamed:
+  🔄 code-exec → bridge v0.2.0 — 9 files, old directory removed
+
+Local registry updated to v0.8.0.
+```
+
+If any items were removed:
+```
+Removed:
+  🗑️ tunnel v0.1.0 — directory deleted
+
+Pinned (kept locally):
+  📌 old-tool v0.1.0 — will not be flagged again
+```
+
+If any extensions were installed or updated, remind the user:
+> "New extensions installed. Restart your Copilot session to activate them, or I can reload extensions now."
+
+If there are errors in the output, report them clearly and suggest retrying individual items.
+
+## Rules
+
+- **Never delete pinned (local-only) items** — items with `local: true` are preserved and skipped during removal checks
+- **Never modify files outside of `.github/extensions/` and `.github/skills/`** — the script only touches these paths
+- **Always show the diff before installing or removing** — never auto-install or auto-remove without user confirmation
+- **Removals are destructive** — they delete the directory from disk. Always confirm with the user before removing
+- **Declined removals get pinned** — if the user declines a removal, pin it with `upgrade.js pin` so it won't be flagged again
+- **Renames are destructive** — they delete the old directory. Always confirm with the user before installing a renamed item
+- **Old names auto-resolve** — if a user requests an old name (e.g. `code-exec`), the script resolves it to the new name via the `renames` map
+- **Channel is sticky** — once set via `channel` command, all future `check` and `install` calls use it. The `channel` field takes precedence over `branch`.
+- **Channel switching is non-destructive** — it updates the registry and shows a diff. The user must explicitly `install` or `remove` items.
+- **Skip items the user doesn't select** — respect their choices
+- **If `gh` CLI is not available**, report the error and stop — the script requires it
+- **If the script fails**, show the error output and suggest checking `gh auth status`

--- a/.github/skills/upgrade/upgrade.js
+++ b/.github/skills/upgrade/upgrade.js
@@ -1,0 +1,837 @@
+#!/usr/bin/env node
+// upgrade.js — Deterministic upgrade script for genesis-based agents.
+// Zero dependencies. Requires: Node.js 18+, gh CLI authenticated.
+//
+// Usage:
+//   node upgrade.js check              — compare local vs remote registry
+//   node upgrade.js install name1,name2 — install/update selected items
+//   node upgrade.js install --all       — install/update everything from remote registry
+//   node upgrade.js remove name1,name2  — remove selected items from local
+//   node upgrade.js pin name1,name2     — pin items to prevent removal
+//   node upgrade.js channel <name>      — switch release channel (e.g. main, frontier)
+//   node upgrade.js migrate --source <owner/repo> [--channel <name>]
+//                                        — rewrite registry: assign non-template items to a package source
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function gh(apiPath) {
+  const raw = execSync(`gh api ${apiPath}`, {
+    encoding: "utf8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return JSON.parse(raw);
+}
+
+function ghBlob(owner, repo, sha) {
+  const blob = gh(`/repos/${owner}/${repo}/git/blobs/${sha}`);
+  return Buffer.from(blob.content, "base64");
+}
+
+function compareSemver(a, b) {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return 1;
+    if ((pa[i] || 0) < (pb[i] || 0)) return -1;
+  }
+  return 0;
+}
+
+function findRepoRoot() {
+  let dir = process.cwd();
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, ".github", "registry.json"))) return dir;
+    dir = path.dirname(dir);
+  }
+  // User-level layout: registry.json at CWD (e.g. ~/.copilot/)
+  if (fs.existsSync(path.join(process.cwd(), "registry.json"))) {
+    return process.cwd();
+  }
+  // Fallback: cwd
+  return process.cwd();
+}
+
+function detectLayout(root) {
+  if (fs.existsSync(path.join(root, ".github", "registry.json"))) return "repo";
+  if (fs.existsSync(path.join(root, "registry.json"))) return "user";
+  return "repo";
+}
+
+function registryPath(root) {
+  return detectLayout(root) === "user"
+    ? path.join(root, "registry.json")
+    : path.join(root, ".github", "registry.json");
+}
+
+function mapPathToLocal(remotePath, layout) {
+  if (layout === "user") {
+    return remotePath.replace(/^\.github\//, "");
+  }
+  return remotePath;
+}
+
+function readLocalRegistry(root) {
+  const p = registryPath(root);
+  if (!fs.existsSync(p)) {
+    return { version: "0.0.0", source: "", extensions: {}, skills: {} };
+  }
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+function writeLocalRegistry(root, registry) {
+  const p = registryPath(root);
+  fs.writeFileSync(p, JSON.stringify(registry, null, 2) + "\n", "utf8");
+}
+
+function makeStagedRemovalPath(itemDir) {
+  const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return path.join(
+    path.dirname(itemDir),
+    `${path.basename(itemDir)}.remove-${suffix}`
+  );
+}
+
+function resolveChannel(local) {
+  return local.channel || local.branch || "main";
+}
+
+function parseSource(source) {
+  const parts = source.split("/");
+  return { owner: parts[0], repo: parts[1] };
+}
+
+// ── Pure logic (testable) ────────────────────────────────────────────────────
+
+function diffRegistries(local, remote) {
+  const result = {
+    source: local.source,
+    remoteVersion: remote.version,
+    localVersion: local.version,
+    new: [],
+    updated: [],
+    current: [],
+    renamed: [],
+    removed: [],
+    localOnly: [],
+    promoted: [],
+  };
+
+  // Build rename lookup: oldName → newName, newName → oldName
+  const renames = remote.renames || {};
+  const reverseRenames = {};
+  for (const [oldName, newName] of Object.entries(renames)) {
+    reverseRenames[newName] = oldName;
+  }
+
+  // Compare both extensions and skills
+  for (const type of ["extensions", "skills"]) {
+    const remoteItems = remote[type] || {};
+    const localItems = local[type] || {};
+    const typeSingular = type === "extensions" ? "extension" : "skill";
+
+    for (const [name, info] of Object.entries(remoteItems)) {
+      const item = {
+        name,
+        type: typeSingular,
+        version: info.version,
+        path: info.path,
+        description: info.description,
+      };
+
+      if (name in localItems) {
+        if (localItems[name].package) {
+          // Template now owns this item — it was previously installed via a package
+          result.promoted.push({
+            ...item,
+            package: localItems[name].package,
+            localVersion: localItems[name].version,
+          });
+        } else if (compareSemver(info.version, localItems[name].version) > 0) {
+          result.updated.push({
+            ...item,
+            localVersion: localItems[name].version,
+          });
+        } else {
+          result.current.push(item);
+        }
+      } else {
+        // Not installed under this name — check if it's a rename
+        const oldName = reverseRenames[name];
+        if (oldName && oldName in localItems) {
+          result.renamed.push({
+            oldName,
+            newName: name,
+            type: typeSingular,
+            version: info.version,
+            localVersion: localItems[oldName].version,
+            description: info.description,
+          });
+        } else {
+          result.new.push(item);
+        }
+      }
+    }
+
+    for (const [name, info] of Object.entries(localItems)) {
+      if (!(name in remoteItems)) {
+        // Skip if this is the old name of a rename (already reported above)
+        if (name in renames) continue;
+
+        const item = {
+          name,
+          type: typeSingular,
+          version: info.version,
+          path: info.path,
+          description: info.description,
+        };
+
+        // Pinned items go to localOnly; unpinned go to removed
+        if (info.local) {
+          result.localOnly.push(item);
+        } else if (info.package) {
+          // Package-installed items not in template are kept (managed by packages skill)
+          result.localOnly.push(item);
+        } else {
+          result.removed.push(item);
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+// ── Check command ────────────────────────────────────────────────────────────
+
+function check() {
+  const root = findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  if (!local.source) {
+    console.error(
+      JSON.stringify({ error: "No source configured in local registry" })
+    );
+    process.exit(1);
+  }
+
+  const { owner, repo } = parseSource(local.source);
+  const branch = resolveChannel(local);
+
+  // Fetch remote registry
+  const remoteRaw = gh(
+    `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${branch}`
+  );
+  const remote = JSON.parse(
+    Buffer.from(remoteRaw.content, "base64").toString("utf8")
+  );
+
+  const result = diffRegistries(local, remote);
+  result.channel = branch;
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ── Install command ──────────────────────────────────────────────────────────
+
+function install(names) {
+  const root = findRepoRoot();
+  const layout = detectLayout(root);
+  const local = readLocalRegistry(root);
+  const { owner, repo } = parseSource(local.source);
+  const branch = resolveChannel(local);
+
+  // Fetch remote registry
+  const remoteRaw = gh(
+    `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${branch}`
+  );
+  const remote = JSON.parse(
+    Buffer.from(remoteRaw.content, "base64").toString("utf8")
+  );
+
+  // Fetch full tree once
+  const tree = gh(`/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`);
+  const treeMap = new Map();
+  for (const entry of tree.tree) {
+    if (entry.type === "blob") {
+      treeMap.set(entry.path, entry.sha);
+    }
+  }
+
+  const result = {
+    installed: [],
+    updated: [],
+    promoted: [],
+    errors: [],
+    registryUpdated: false,
+  };
+
+  const requestedNames = new Set(names);
+
+  // Build rename lookup and resolve old names to new names
+  const renames = remote.renames || {};
+  const reverseRenames = {};
+  for (const [oldName, newName] of Object.entries(renames)) {
+    reverseRenames[newName] = oldName;
+    if (requestedNames.has(oldName)) {
+      requestedNames.delete(oldName);
+      requestedNames.add(newName);
+    }
+  }
+
+  for (const type of ["extensions", "skills"]) {
+    const remoteItems = remote[type] || {};
+    const localItems = local[type] || {};
+
+    for (const [name, info] of Object.entries(remoteItems)) {
+      if (!requestedNames.has(name)) continue;
+
+      const isNew = !(name in localItems);
+      const itemPath = info.path; // remote path for tree matching (e.g. ".github/extensions/cron")
+      const localItemPath = mapPathToLocal(itemPath, layout);
+
+      try {
+        // Find all files under this item's path in the tree
+        const prefix = itemPath.endsWith("/") ? itemPath : itemPath + "/";
+        const files = [];
+        for (const [filePath, sha] of treeMap) {
+          if (filePath.startsWith(prefix) || filePath === itemPath) {
+            files.push({ path: filePath, sha });
+          }
+        }
+
+        if (files.length === 0) {
+          result.errors.push({
+            name,
+            error: `No files found in tree under ${itemPath}`,
+          });
+          continue;
+        }
+
+        // Download and write each file
+        let fileCount = 0;
+        for (const file of files) {
+          const content = ghBlob(owner, repo, file.sha);
+          const localPath = path.join(root, mapPathToLocal(file.path, layout));
+          const dir = path.dirname(localPath);
+
+          fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync(localPath, content);
+          fileCount++;
+        }
+
+        // Run npm install if package.json exists
+        const pkgPath = path.join(root, localItemPath, "package.json");
+        let npmInstalled = false;
+        if (fs.existsSync(pkgPath)) {
+          try {
+            execSync("npm install --production", {
+              cwd: path.join(root, localItemPath),
+              encoding: "utf8",
+              stdio: "pipe",
+            });
+            npmInstalled = true;
+          } catch (e) {
+            result.errors.push({
+              name,
+              error: `npm install failed: ${e.message.slice(0, 200)}`,
+            });
+          }
+        }
+
+        // Update local registry — remove package field if promoting
+        if (!local[type]) local[type] = {};
+        const wasPackage = localItems[name] && localItems[name].package;
+        local[type][name] = {
+          version: info.version,
+          path: localItemPath,
+          description: info.description,
+        };
+
+        const entry = {
+          name,
+          type: type === "extensions" ? "extension" : "skill",
+          version: info.version,
+          files: fileCount,
+          npmInstalled,
+        };
+
+        // Handle promotion — clean up package tracking
+        if (wasPackage) {
+          const pkgSource = localItems[name].package;
+          entry.promotedFrom = pkgSource;
+          if (Array.isArray(local.packages)) {
+            for (const pkg of local.packages) {
+              if (pkg.source === pkgSource && pkg.installed) {
+                const pkgType = pkg.installed[type];
+                if (pkgType && pkgType[name]) {
+                  delete pkgType[name];
+                }
+              }
+            }
+            // Remove empty package entries
+            local.packages = local.packages.filter((pkg) => {
+              if (!pkg.installed) return false;
+              const exts = Object.keys(pkg.installed.extensions || {});
+              const skills = Object.keys(pkg.installed.skills || {});
+              return exts.length > 0 || skills.length > 0;
+            });
+          }
+          result.promoted.push(entry);
+        } else if (isNew) {
+          result.installed.push(entry);
+        } else {
+          result.updated.push({
+            ...entry,
+            from: localItems[name].version,
+          });
+        }
+
+        // Handle rename — clean up old directory and registry entry
+        const oldName = reverseRenames[name];
+        if (oldName) {
+          for (const t of ["extensions", "skills"]) {
+            if (local[t] && local[t][oldName]) {
+              const oldDir = path.join(root, local[t][oldName].path);
+              if (fs.existsSync(oldDir)) {
+                fs.rmSync(oldDir, { recursive: true, force: true });
+              }
+              delete local[t][oldName];
+              break;
+            }
+          }
+          entry.renamedFrom = oldName;
+        }
+      } catch (e) {
+        result.errors.push({
+          name,
+          error: e.message.slice(0, 300),
+        });
+      }
+    }
+  }
+
+  // Update registry version and write
+  if (result.installed.length > 0 || result.updated.length > 0 || result.promoted.length > 0) {
+    local.version = remote.version;
+    writeLocalRegistry(root, local);
+    result.registryUpdated = true;
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// ── Remove command ───────────────────────────────────────────────────────────
+
+function remove(names, root) {
+  root = root || findRepoRoot();
+  const local = readLocalRegistry(root);
+  const pendingRemovals = [];
+
+  const result = {
+    removed: [],
+    errors: [],
+    registryUpdated: false,
+  };
+
+  for (const name of names) {
+    let found = false;
+
+    for (const type of ["extensions", "skills"]) {
+      const items = local[type] || {};
+      if (!(name in items)) continue;
+
+      found = true;
+      const info = items[name];
+      const itemDir = path.join(root, info.path);
+      let stagedDir = null;
+
+      try {
+        if (fs.existsSync(itemDir)) {
+          stagedDir = makeStagedRemovalPath(itemDir);
+          fs.renameSync(itemDir, stagedDir);
+        }
+
+        delete local[type][name];
+        pendingRemovals.push({
+          name,
+          info,
+          type,
+          itemDir,
+          stagedDir,
+        });
+      } catch (e) {
+        if (stagedDir && fs.existsSync(stagedDir)) {
+          fs.renameSync(stagedDir, itemDir);
+        }
+        result.errors.push({
+          name,
+          error: e.message.slice(0, 300),
+        });
+      }
+      break;
+    }
+
+    if (!found) {
+      result.errors.push({
+        name,
+        error: "Not found in local registry (extensions or skills)",
+      });
+    }
+  }
+
+  if (pendingRemovals.length > 0) {
+    try {
+      writeLocalRegistry(root, local);
+      result.registryUpdated = true;
+
+      for (const item of pendingRemovals) {
+        if (item.stagedDir && fs.existsSync(item.stagedDir)) {
+          fs.rmSync(item.stagedDir, { recursive: true, force: true });
+        }
+
+        result.removed.push({
+          name: item.name,
+          type: item.type === "extensions" ? "extension" : "skill",
+          version: item.info.version,
+          path: item.info.path,
+        });
+      }
+    } catch (e) {
+      for (let i = pendingRemovals.length - 1; i >= 0; i--) {
+        const item = pendingRemovals[i];
+        local[item.type][item.name] = item.info;
+
+        if (item.stagedDir && fs.existsSync(item.stagedDir)) {
+          fs.renameSync(item.stagedDir, item.itemDir);
+        }
+
+        result.errors.push({
+          name: item.name,
+          error: `Failed to update registry: ${e.message.slice(0, 300)}`,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+// ── Pin command ──────────────────────────────────────────────────────────────
+
+function pin(names, root) {
+  root = root || findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  const result = {
+    pinned: [],
+    errors: [],
+  };
+
+  for (const name of names) {
+    let found = false;
+
+    for (const type of ["extensions", "skills"]) {
+      const items = local[type] || {};
+      if (!(name in items)) continue;
+
+      found = true;
+      items[name].local = true;
+
+      result.pinned.push({
+        name,
+        type: type === "extensions" ? "extension" : "skill",
+        version: items[name].version,
+      });
+      break;
+    }
+
+    if (!found) {
+      result.errors.push({
+        name,
+        error: "Not found in local registry (extensions or skills)",
+      });
+    }
+  }
+
+  if (result.pinned.length > 0) {
+    writeLocalRegistry(root, local);
+  }
+
+  return result;
+}
+
+// ── Channel command ──────────────────────────────────────────────────────────
+
+function channel(name) {
+  const root = findRepoRoot();
+  const local = readLocalRegistry(root);
+
+  if (!local.source) {
+    console.error(
+      JSON.stringify({ error: "No source configured in local registry" })
+    );
+    process.exit(1);
+  }
+
+  const previous = resolveChannel(local);
+
+  if (name === previous) {
+    console.log(
+      JSON.stringify({
+        channel: name,
+        changed: false,
+        message: `Already on channel "${name}".`,
+      })
+    );
+    return;
+  }
+
+  const { owner, repo } = parseSource(local.source);
+
+  // Fetch remote registry from the target channel branch
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${name}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    console.error(
+      JSON.stringify({
+        error: `Failed to fetch registry from channel "${name}". Does the branch exist? ${e.message.slice(0, 200)}`,
+      })
+    );
+    process.exit(1);
+  }
+
+  // Update the channel in local registry
+  local.channel = name;
+  delete local.branch; // channel supersedes branch
+  writeLocalRegistry(root, local);
+
+  // Diff against the target channel's registry
+  const diff = diffRegistries(local, remote);
+  diff.channel = name;
+  diff.previousChannel = previous;
+  diff.changed = true;
+
+  console.log(JSON.stringify(diff, null, 2));
+}
+
+// ── Migrate command ──────────────────────────────────────────────────────────
+
+function migrateRegistry(local, remote, source) {
+  const migrated = [];
+  const skipped = [];
+
+  // For each local item NOT in the target channel's registry, assign it to the package source
+  for (const type of ["extensions", "skills"]) {
+    const remoteItems = remote[type] || {};
+    const localItems = local[type] || {};
+
+    for (const [name, info] of Object.entries(localItems)) {
+      if (name in remoteItems) {
+        skipped.push({ name, type: type === "extensions" ? "extension" : "skill", reason: "in_template" });
+        continue;
+      }
+      if (info.local) {
+        skipped.push({ name, type: type === "extensions" ? "extension" : "skill", reason: "pinned" });
+        continue;
+      }
+      if (info.package) {
+        skipped.push({ name, type: type === "extensions" ? "extension" : "skill", reason: "already_package" });
+        continue;
+      }
+
+      // Assign to package
+      local[type][name] = { ...info, package: source };
+      migrated.push({
+        name,
+        type: type === "extensions" ? "extension" : "skill",
+        version: info.version,
+      });
+    }
+  }
+
+  // Build the packages[] entry for migrated items
+  if (migrated.length > 0) {
+    if (!local.packages) local.packages = [];
+
+    let pkgEntry = local.packages.find((p) => p.source === source);
+    if (!pkgEntry) {
+      pkgEntry = { source, ref: "main", installed: { extensions: {}, skills: {} } };
+      local.packages.push(pkgEntry);
+    }
+    if (!pkgEntry.installed) pkgEntry.installed = { extensions: {}, skills: {} };
+
+    for (const item of migrated) {
+      const type = item.type === "extension" ? "extensions" : "skills";
+      const info = local[type][item.name];
+      pkgEntry.installed[type][item.name] = {
+        version: info.version,
+        path: info.path,
+        description: info.description,
+      };
+    }
+  }
+
+  return { migrated, skipped };
+}
+
+function migrate(source, targetChannel) {
+  const root = findRepoRoot();
+  const local = readLocalRegistry(root);
+  const currentChannel = resolveChannel(local);
+
+  if (!local.source) {
+    return { error: "No source configured in local registry" };
+  }
+
+  const { owner, repo } = parseSource(local.source);
+
+  let remote;
+  try {
+    const remoteRaw = gh(
+      `/repos/${owner}/${repo}/contents/.github/registry.json?ref=${targetChannel}`
+    );
+    remote = JSON.parse(
+      Buffer.from(remoteRaw.content, "base64").toString("utf8")
+    );
+  } catch (e) {
+    return {
+      error: `Failed to fetch registry from channel "${targetChannel}". ${e.message.slice(0, 200)}`,
+    };
+  }
+
+  const { migrated, skipped } = migrateRegistry(local, remote, source);
+
+  // Switch channel to target
+  local.channel = targetChannel;
+  delete local.branch;
+
+  writeLocalRegistry(root, local);
+
+  return {
+    source,
+    targetChannel,
+    previousChannel: currentChannel,
+    migrated,
+    skipped,
+    registryUpdated: true,
+  };
+}
+
+// ── Exports (for testing) ────────────────────────────────────────────────────
+
+module.exports = { compareSemver, diffRegistries, remove, pin, resolveChannel, detectLayout, mapPathToLocal, migrate, migrateRegistry };
+
+// ── CLI entry ────────────────────────────────────────────────────────────────
+
+if (require.main === module) {
+  const [, , command, ...args] = process.argv;
+
+  switch (command) {
+    case "check":
+      check();
+      break;
+    case "install":
+      if (args[0] === "--all") {
+        const allRoot = findRepoRoot();
+        const allLocal = readLocalRegistry(allRoot);
+        const allParsed = parseSource(allLocal.source);
+        const allBranch = resolveChannel(allLocal);
+        const allRemoteRaw = gh(
+          `/repos/${allParsed.owner}/${allParsed.repo}/contents/.github/registry.json?ref=${allBranch}`
+        );
+        const allRemote = JSON.parse(
+          Buffer.from(allRemoteRaw.content, "base64").toString("utf8")
+        );
+        const allNames = [
+          ...Object.keys(allRemote.extensions || {}),
+          ...Object.keys(allRemote.skills || {}),
+        ];
+        if (allNames.length === 0) {
+          console.log(JSON.stringify({ installed: [], updated: [], errors: [], note: "No items in remote registry" }));
+          break;
+        }
+        install(allNames);
+      } else if (!args[0]) {
+        console.error(
+          JSON.stringify({
+            error: "Usage: node upgrade.js install name1,name2,... | --all",
+          })
+        );
+        process.exit(1);
+      } else {
+        install(args[0].split(",").map((s) => s.trim()));
+      }
+      break;
+    case "remove":
+      if (!args[0]) {
+        console.error(
+          JSON.stringify({
+            error: "Usage: node upgrade.js remove name1,name2,...",
+          })
+        );
+        process.exit(1);
+      }
+      console.log(JSON.stringify(remove(args[0].split(",").map((s) => s.trim())), null, 2));
+      break;
+    case "pin":
+      if (!args[0]) {
+        console.error(
+          JSON.stringify({
+            error: "Usage: node upgrade.js pin name1,name2,...",
+          })
+        );
+        process.exit(1);
+      }
+      console.log(JSON.stringify(pin(args[0].split(",").map((s) => s.trim())), null, 2));
+      break;
+    case "channel":
+      if (!args[0]) {
+        console.error(
+          JSON.stringify({
+            error: 'Usage: node upgrade.js channel <name> (e.g. "main", "frontier")',
+          })
+        );
+        process.exit(1);
+      }
+      channel(args[0].trim());
+      break;
+    case "migrate": {
+      // Parse --source and --channel flags
+      let source = null;
+      let targetChannel = "main";
+      for (let i = 0; i < args.length; i++) {
+        if (args[i] === "--source" && args[i + 1]) {
+          source = args[++i].trim();
+        } else if (args[i] === "--channel" && args[i + 1]) {
+          targetChannel = args[++i].trim();
+        }
+      }
+      if (!source) {
+        console.error(
+          JSON.stringify({
+            error: 'Usage: node upgrade.js migrate --source <owner/repo> [--channel <name>]',
+          })
+        );
+        process.exit(1);
+      }
+      console.log(JSON.stringify(migrate(source, targetChannel), null, 2));
+      break;
+    }
+    default:
+      console.error(
+        JSON.stringify({
+          error: `Unknown command: ${command}. Use "check", "install", "remove", "pin", "channel", or "migrate".`,
+        })
+      );
+      process.exit(1);
+  }
+}

--- a/.github/skills/upgrade/upgrade.test.js
+++ b/.github/skills/upgrade/upgrade.test.js
@@ -1,0 +1,1097 @@
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { compareSemver, diffRegistries, remove, pin, resolveChannel, migrateRegistry } = require("./upgrade.js");
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function makeTempRepo(registry, dirs = []) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "upgrade-test-"));
+  const ghDir = path.join(root, ".github");
+  fs.mkdirSync(ghDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(ghDir, "registry.json"),
+    JSON.stringify(registry, null, 2),
+    "utf8"
+  );
+  for (const dir of dirs) {
+    const full = path.join(root, dir);
+    fs.mkdirSync(full, { recursive: true });
+    fs.writeFileSync(path.join(full, "index.js"), "// stub", "utf8");
+  }
+  return root;
+}
+
+function readRegistry(root) {
+  return JSON.parse(
+    fs.readFileSync(path.join(root, ".github", "registry.json"), "utf8")
+  );
+}
+
+// ── compareSemver ────────────────────────────────────────────────────────────
+
+describe("compareSemver", () => {
+  it("returns 0 for equal versions", () => {
+    assert.equal(compareSemver("1.0.0", "1.0.0"), 0);
+  });
+
+  it("returns 1 when a > b (major)", () => {
+    assert.equal(compareSemver("2.0.0", "1.0.0"), 1);
+  });
+
+  it("returns -1 when a < b (minor)", () => {
+    assert.equal(compareSemver("1.0.0", "1.1.0"), -1);
+  });
+
+  it("returns 1 when a > b (patch)", () => {
+    assert.equal(compareSemver("1.0.2", "1.0.1"), 1);
+  });
+
+  it("handles missing patch as 0", () => {
+    assert.equal(compareSemver("1.0", "1.0.0"), 0);
+  });
+});
+
+// ── diffRegistries — helpers ─────────────────────────────────────────────────
+
+function makeLocal(overrides = {}) {
+  return {
+    version: "0.1.0",
+    source: "owner/repo",
+    extensions: {},
+    skills: {},
+    ...overrides,
+  };
+}
+
+function makeRemote(overrides = {}) {
+  return {
+    version: "0.2.0",
+    extensions: {},
+    skills: {},
+    ...overrides,
+  };
+}
+
+// ── diffRegistries — current ─────────────────────────────────────────────────
+
+describe("diffRegistries — current items", () => {
+  it("identifies items at same version as current", () => {
+    const local = makeLocal({
+      extensions: {
+        cron: { version: "0.1.0", path: ".github/extensions/cron", description: "Cron" },
+      },
+    });
+    const remote = makeRemote({
+      extensions: {
+        cron: { version: "0.1.0", path: ".github/extensions/cron", description: "Cron" },
+      },
+    });
+    const result = diffRegistries(local, remote);
+    assert.equal(result.current.length, 1);
+    assert.equal(result.current[0].name, "cron");
+  });
+});
+
+// ── diffRegistries — new ─────────────────────────────────────────────────────
+
+describe("diffRegistries — new items", () => {
+  it("identifies items in remote but not local as new", () => {
+    const local = makeLocal();
+    const remote = makeRemote({
+      skills: {
+        "daily-report": { version: "0.1.0", path: ".github/skills/daily-report", description: "DR" },
+      },
+    });
+    const result = diffRegistries(local, remote);
+    assert.equal(result.new.length, 1);
+    assert.equal(result.new[0].name, "daily-report");
+    assert.equal(result.new[0].type, "skill");
+  });
+});
+
+// ── diffRegistries — updated ─────────────────────────────────────────────────
+
+describe("diffRegistries — updated items", () => {
+  it("identifies items with higher remote version as updated", () => {
+    const local = makeLocal({
+      extensions: {
+        cron: { version: "0.1.0", path: ".github/extensions/cron", description: "Cron" },
+      },
+    });
+    const remote = makeRemote({
+      extensions: {
+        cron: { version: "0.2.0", path: ".github/extensions/cron", description: "Cron" },
+      },
+    });
+    const result = diffRegistries(local, remote);
+    assert.equal(result.updated.length, 1);
+    assert.equal(result.updated[0].name, "cron");
+    assert.equal(result.updated[0].localVersion, "0.1.0");
+  });
+});
+
+// ── diffRegistries — renamed ─────────────────────────────────────────────────
+
+describe("diffRegistries — renamed items", () => {
+  it("detects rename when old name exists locally and renames map points to new name", () => {
+    const local = makeLocal({
+      extensions: {
+        "code-exec": { version: "0.1.0", path: ".github/extensions/code-exec", description: "Old" },
+      },
+    });
+    const remote = makeRemote({
+      extensions: {
+        bridge: { version: "0.2.0", path: ".github/extensions/bridge", description: "New" },
+      },
+      renames: { "code-exec": "bridge" },
+    });
+    const result = diffRegistries(local, remote);
+    assert.equal(result.renamed.length, 1);
+    assert.equal(result.renamed[0].oldName, "code-exec");
+    assert.equal(result.renamed[0].newName, "bridge");
+    // Old name should NOT appear in removed
+    assert.equal(result.removed.length, 0);
+  });
+});
+
+// ── diffRegistries — removed ─────────────────────────────────────────────────
+
+describe("diffRegistries — removed items", () => {
+  it("identifies items in local but not remote as removed", () => {
+    const local = makeLocal({
+      extensions: {
+        tunnel: { version: "0.1.0", path: ".github/extensions/tunnel", description: "Tunnel" },
+      },
+    });
+    const remote = makeRemote();
+    const result = diffRegistries(local, remote);
+    assert.equal(result.removed.length, 1);
+    assert.equal(result.removed[0].name, "tunnel");
+    assert.equal(result.localOnly.length, 0);
+  });
+
+  it("does NOT flag pinned items as removed", () => {
+    const local = makeLocal({
+      extensions: {
+        tunnel: { version: "0.1.0", path: ".github/extensions/tunnel", description: "Tunnel", local: true },
+      },
+    });
+    const remote = makeRemote();
+    const result = diffRegistries(local, remote);
+    assert.equal(result.removed.length, 0);
+    assert.equal(result.localOnly.length, 1);
+    assert.equal(result.localOnly[0].name, "tunnel");
+  });
+
+  it("does NOT flag old rename names as removed", () => {
+    const local = makeLocal({
+      extensions: {
+        "code-exec": { version: "0.1.0", path: ".github/extensions/code-exec", description: "Old" },
+      },
+    });
+    const remote = makeRemote({
+      extensions: {
+        bridge: { version: "0.2.0", path: ".github/extensions/bridge", description: "New" },
+      },
+      renames: { "code-exec": "bridge" },
+    });
+    const result = diffRegistries(local, remote);
+    assert.equal(result.removed.length, 0);
+  });
+});
+
+// ── diffRegistries — mixed scenario ──────────────────────────────────────────
+
+describe("diffRegistries — mixed scenario", () => {
+  it("correctly categorizes a complex registry diff", () => {
+    const local = makeLocal({
+      version: "0.5.0",
+      extensions: {
+        cron: { version: "0.1.0", path: ".github/extensions/cron", description: "Cron" },
+        tunnel: { version: "0.1.0", path: ".github/extensions/tunnel", description: "Tunnel" },
+        canvas: { version: "0.1.0", path: ".github/extensions/canvas", description: "Canvas" },
+        "code-exec": { version: "0.1.0", path: ".github/extensions/code-exec", description: "Old" },
+        custom: { version: "0.1.0", path: ".github/extensions/custom", description: "Custom", local: true },
+      },
+      skills: {},
+    });
+    const remote = makeRemote({
+      version: "0.6.0",
+      extensions: {
+        cron: { version: "0.1.0", path: ".github/extensions/cron", description: "Cron" },
+        canvas: { version: "0.2.0", path: ".github/extensions/canvas", description: "Canvas v2" },
+        bridge: { version: "0.2.0", path: ".github/extensions/bridge", description: "Bridge" },
+        newext: { version: "0.1.0", path: ".github/extensions/newext", description: "New Extension" },
+      },
+      skills: {},
+      renames: { "code-exec": "bridge" },
+    });
+
+    const result = diffRegistries(local, remote);
+
+    // cron 0.1.0 == 0.1.0 → current
+    assert.equal(result.current.length, 1);
+    assert.equal(result.current[0].name, "cron");
+
+    // canvas 0.1.0 < 0.2.0 → updated
+    assert.equal(result.updated.length, 1);
+    assert.equal(result.updated[0].name, "canvas");
+
+    // code-exec → bridge → renamed
+    assert.equal(result.renamed.length, 1);
+    assert.equal(result.renamed[0].oldName, "code-exec");
+    assert.equal(result.renamed[0].newName, "bridge");
+
+    // newext not in local → new
+    assert.equal(result.new.length, 1);
+    assert.equal(result.new[0].name, "newext");
+
+    // tunnel in local, not in remote, not pinned → removed
+    assert.equal(result.removed.length, 1);
+    assert.equal(result.removed[0].name, "tunnel");
+
+    // custom is pinned (local: true) → localOnly
+    assert.equal(result.localOnly.length, 1);
+    assert.equal(result.localOnly[0].name, "custom");
+  });
+});
+
+// ── remove ───────────────────────────────────────────────────────────────────
+
+describe("remove", () => {
+  it("deletes directory and removes from registry", () => {
+    const registry = {
+      version: "0.1.0",
+      source: "owner/repo",
+      extensions: {
+        tunnel: { version: "0.1.0", path: ".github/extensions/tunnel", description: "Tunnel" },
+        cron: { version: "0.1.0", path: ".github/extensions/cron", description: "Cron" },
+      },
+      skills: {},
+    };
+    const root = makeTempRepo(registry, [".github/extensions/tunnel", ".github/extensions/cron"]);
+
+    const result = remove(["tunnel"], root);
+
+    assert.equal(result.removed.length, 1);
+    assert.equal(result.removed[0].name, "tunnel");
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.registryUpdated, true);
+
+    // Directory should be gone
+    assert.equal(fs.existsSync(path.join(root, ".github/extensions/tunnel")), false);
+    // Cron should still be there
+    assert.equal(fs.existsSync(path.join(root, ".github/extensions/cron")), true);
+
+    // Registry should be updated
+    const updated = readRegistry(root);
+    assert.equal("tunnel" in (updated.extensions || {}), false);
+    assert.equal("cron" in (updated.extensions || {}), true);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("removes a skill", () => {
+    const registry = {
+      version: "0.1.0",
+      source: "owner/repo",
+      extensions: {},
+      skills: {
+        commit: { version: "0.1.0", path: ".github/skills/commit", description: "Commit" },
+      },
+    };
+    const root = makeTempRepo(registry, [".github/skills/commit"]);
+
+    const result = remove(["commit"], root);
+
+    assert.equal(result.removed.length, 1);
+    assert.equal(result.removed[0].type, "skill");
+    assert.equal(fs.existsSync(path.join(root, ".github/skills/commit")), false);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns error for unknown item", () => {
+    const registry = { version: "0.1.0", source: "owner/repo", extensions: {}, skills: {} };
+    const root = makeTempRepo(registry);
+
+    const result = remove(["nonexistent"], root);
+
+    assert.equal(result.removed.length, 0);
+    assert.equal(result.errors.length, 1);
+    assert.equal(result.registryUpdated, false);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("handles multiple removals at once", () => {
+    const registry = {
+      version: "0.1.0",
+      source: "owner/repo",
+      extensions: {
+        a: { version: "0.1.0", path: ".github/extensions/a", description: "A" },
+        b: { version: "0.1.0", path: ".github/extensions/b", description: "B" },
+      },
+      skills: {},
+    };
+    const root = makeTempRepo(registry, [".github/extensions/a", ".github/extensions/b"]);
+
+    const result = remove(["a", "b"], root);
+
+    assert.equal(result.removed.length, 2);
+    assert.equal(fs.existsSync(path.join(root, ".github/extensions/a")), false);
+    assert.equal(fs.existsSync(path.join(root, ".github/extensions/b")), false);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("rolls back staged directory removals if registry write fails", () => {
+    const registry = {
+      version: "0.1.0",
+      source: "owner/repo",
+      extensions: {
+        tunnel: { version: "0.1.0", path: ".github/extensions/tunnel", description: "Tunnel" },
+      },
+      skills: {},
+    };
+    const root = makeTempRepo(registry, [".github/extensions/tunnel"]);
+    const registryPath = path.join(root, ".github", "registry.json");
+    const originalWriteFileSync = fs.writeFileSync;
+
+    fs.writeFileSync = function (...args) {
+      if (args[0] === registryPath) {
+        throw new Error("disk full");
+      }
+      return originalWriteFileSync.apply(this, args);
+    };
+
+    try {
+      const result = remove(["tunnel"], root);
+
+      assert.equal(result.removed.length, 0);
+      assert.equal(result.registryUpdated, false);
+      assert.equal(result.errors.length, 1);
+      assert.match(result.errors[0].error, /Failed to update registry: disk full/);
+      assert.equal(fs.existsSync(path.join(root, ".github/extensions/tunnel")), true);
+
+      const updated = readRegistry(root);
+      assert.equal("tunnel" in (updated.extensions || {}), true);
+    } finally {
+      fs.writeFileSync = originalWriteFileSync;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── pin ──────────────────────────────────────────────────────────────────────
+
+describe("pin", () => {
+  it("sets local:true on the item in registry", () => {
+    const registry = {
+      version: "0.1.0",
+      source: "owner/repo",
+      extensions: {
+        tunnel: { version: "0.1.0", path: ".github/extensions/tunnel", description: "Tunnel" },
+      },
+      skills: {},
+    };
+    const root = makeTempRepo(registry, [".github/extensions/tunnel"]);
+
+    const result = pin(["tunnel"], root);
+
+    assert.equal(result.pinned.length, 1);
+    assert.equal(result.pinned[0].name, "tunnel");
+    assert.equal(result.errors.length, 0);
+
+    // Registry should have local: true
+    const updated = readRegistry(root);
+    assert.equal(updated.extensions.tunnel.local, true);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns error for unknown item", () => {
+    const registry = { version: "0.1.0", source: "owner/repo", extensions: {}, skills: {} };
+    const root = makeTempRepo(registry);
+
+    const result = pin(["nonexistent"], root);
+
+    assert.equal(result.pinned.length, 0);
+    assert.equal(result.errors.length, 1);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("pinned item is then skipped by diffRegistries as localOnly", () => {
+    const registry = {
+      version: "0.1.0",
+      source: "owner/repo",
+      extensions: {
+        tunnel: { version: "0.1.0", path: ".github/extensions/tunnel", description: "Tunnel" },
+      },
+      skills: {},
+    };
+    const root = makeTempRepo(registry, [".github/extensions/tunnel"]);
+
+    // Pin it
+    pin(["tunnel"], root);
+
+    // Now diff — tunnel should be localOnly, not removed
+    const local = readRegistry(root);
+    const remote = { version: "0.2.0", extensions: {}, skills: {} };
+    const diff = diffRegistries(local, remote);
+
+    assert.equal(diff.removed.length, 0);
+    assert.equal(diff.localOnly.length, 1);
+    assert.equal(diff.localOnly[0].name, "tunnel");
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── resolveChannel ───────────────────────────────────────────────────────────
+
+describe("resolveChannel", () => {
+  it("defaults to main when no channel or branch set", () => {
+    assert.equal(resolveChannel({ version: "0.1.0", source: "o/r" }), "main");
+  });
+
+  it("returns channel when set", () => {
+    assert.equal(resolveChannel({ channel: "frontier" }), "frontier");
+  });
+
+  it("falls back to branch when channel is not set", () => {
+    assert.equal(resolveChannel({ branch: "develop" }), "develop");
+  });
+
+  it("channel takes precedence over branch", () => {
+    assert.equal(resolveChannel({ channel: "frontier", branch: "develop" }), "frontier");
+  });
+});
+
+// ── diffRegistries — channel switching scenarios ─────────────────────────────
+
+describe("diffRegistries — channel switching", () => {
+  it("switching from main to frontier shows new items", () => {
+    const local = makeLocal({
+      channel: "main",
+      extensions: {
+        cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
+        canvas: { version: "0.1.3", path: ".github/extensions/canvas", description: "Canvas" },
+      },
+      skills: {
+        commit: { version: "0.1.0", path: ".github/skills/commit", description: "Commit" },
+        upgrade: { version: "0.4.0", path: ".github/skills/upgrade", description: "Upgrade" },
+      },
+    });
+    const frontierRemote = makeRemote({
+      extensions: {
+        cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
+        canvas: { version: "0.1.3", path: ".github/extensions/canvas", description: "Canvas" },
+        heartbeat: { version: "0.1.2", path: ".github/extensions/heartbeat", description: "Heartbeat" },
+        "code-exec": { version: "0.1.2", path: ".github/extensions/code-exec", description: "Code Exec" },
+      },
+      skills: {
+        commit: { version: "0.1.0", path: ".github/skills/commit", description: "Commit" },
+        upgrade: { version: "0.4.0", path: ".github/skills/upgrade", description: "Upgrade" },
+        "agent-comms": { version: "0.1.0", path: ".github/skills/agent-comms", description: "Agent Comms" },
+      },
+    });
+
+    const result = diffRegistries(local, frontierRemote);
+
+    // Everything from main should be current
+    assert.equal(result.current.length, 4);
+    // Insiders-only items should be new
+    assert.equal(result.new.length, 3);
+    const newNames = result.new.map((i) => i.name).sort();
+    assert.deepEqual(newNames, ["agent-comms", "code-exec", "heartbeat"]);
+    // Nothing removed
+    assert.equal(result.removed.length, 0);
+  });
+
+  it("switching from frontier to main shows removable items", () => {
+    const local = makeLocal({
+      channel: "frontier",
+      extensions: {
+        cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
+        canvas: { version: "0.1.3", path: ".github/extensions/canvas", description: "Canvas" },
+        heartbeat: { version: "0.1.2", path: ".github/extensions/heartbeat", description: "Heartbeat" },
+        "code-exec": { version: "0.1.2", path: ".github/extensions/code-exec", description: "Code Exec" },
+      },
+      skills: {
+        commit: { version: "0.1.0", path: ".github/skills/commit", description: "Commit" },
+        upgrade: { version: "0.4.0", path: ".github/skills/upgrade", description: "Upgrade" },
+        "agent-comms": { version: "0.1.0", path: ".github/skills/agent-comms", description: "Agent Comms" },
+      },
+    });
+    const mainRemote = makeRemote({
+      extensions: {
+        cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
+        canvas: { version: "0.1.3", path: ".github/extensions/canvas", description: "Canvas" },
+      },
+      skills: {
+        commit: { version: "0.1.0", path: ".github/skills/commit", description: "Commit" },
+        upgrade: { version: "0.4.0", path: ".github/skills/upgrade", description: "Upgrade" },
+      },
+    });
+
+    const result = diffRegistries(local, mainRemote);
+
+    // Main items should be current
+    assert.equal(result.current.length, 4);
+    // Insiders-only items should be flagged as removed
+    assert.equal(result.removed.length, 3);
+    const removedNames = result.removed.map((i) => i.name).sort();
+    assert.deepEqual(removedNames, ["agent-comms", "code-exec", "heartbeat"]);
+    // Nothing new
+    assert.equal(result.new.length, 0);
+  });
+});
+
+// ── detectLayout ─────────────────────────────────────────────────────────────
+
+const { detectLayout, mapPathToLocal } = require("./upgrade.js");
+
+describe("detectLayout", () => {
+  it("returns repo when .github/registry.json exists", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "layout-test-"));
+    const ghDir = path.join(root, ".github");
+    fs.mkdirSync(ghDir, { recursive: true });
+    fs.writeFileSync(path.join(ghDir, "registry.json"), "{}", "utf8");
+
+    assert.equal(detectLayout(root), "repo");
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("returns user when only registry.json exists at root", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "layout-test-"));
+    fs.writeFileSync(path.join(root, "registry.json"), "{}", "utf8");
+
+    assert.equal(detectLayout(root), "user");
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("defaults to repo when no registry exists", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "layout-test-"));
+
+    assert.equal(detectLayout(root), "repo");
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("prefers repo layout when both exist", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "layout-test-"));
+    const ghDir = path.join(root, ".github");
+    fs.mkdirSync(ghDir, { recursive: true });
+    fs.writeFileSync(path.join(ghDir, "registry.json"), "{}", "utf8");
+    fs.writeFileSync(path.join(root, "registry.json"), "{}", "utf8");
+
+    assert.equal(detectLayout(root), "repo");
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── mapPathToLocal ───────────────────────────────────────────────────────────
+
+describe("mapPathToLocal", () => {
+  it("strips .github/ prefix for user layout", () => {
+    assert.equal(mapPathToLocal(".github/extensions/cron", "user"), "extensions/cron");
+  });
+
+  it("strips .github/ prefix from nested paths for user layout", () => {
+    assert.equal(mapPathToLocal(".github/skills/commit/SKILL.md", "user"), "skills/commit/SKILL.md");
+  });
+
+  it("passes through paths unchanged for repo layout", () => {
+    assert.equal(mapPathToLocal(".github/extensions/cron", "repo"), ".github/extensions/cron");
+  });
+
+  it("handles paths without .github/ prefix in user layout", () => {
+    assert.equal(mapPathToLocal("extensions/cron", "user"), "extensions/cron");
+  });
+});
+
+// ── remove (user-level layout) ───────────────────────────────────────────────
+
+function makeTempUserDir(registry, dirs = []) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "user-upgrade-test-"));
+  fs.writeFileSync(
+    path.join(root, "registry.json"),
+    JSON.stringify(registry, null, 2),
+    "utf8"
+  );
+  for (const dir of dirs) {
+    const full = path.join(root, dir);
+    fs.mkdirSync(full, { recursive: true });
+    fs.writeFileSync(path.join(full, "index.js"), "// stub", "utf8");
+  }
+  return root;
+}
+
+function readUserRegistry(root) {
+  return JSON.parse(
+    fs.readFileSync(path.join(root, "registry.json"), "utf8")
+  );
+}
+
+describe("remove (user layout)", () => {
+  it("deletes directory and removes from user-level registry", () => {
+    const registry = {
+      version: "0.1.0",
+      source: "owner/repo",
+      extensions: {
+        cron: { version: "0.1.4", path: "extensions/cron", description: "Cron" },
+        canvas: { version: "0.1.3", path: "extensions/canvas", description: "Canvas" },
+      },
+      skills: {},
+    };
+    const root = makeTempUserDir(registry, ["extensions/cron", "extensions/canvas"]);
+
+    const result = remove(["cron"], root);
+
+    assert.equal(result.removed.length, 1);
+    assert.equal(result.removed[0].name, "cron");
+    assert.equal(result.errors.length, 0);
+    assert.equal(result.registryUpdated, true);
+
+    // Directory should be gone
+    assert.equal(fs.existsSync(path.join(root, "extensions/cron")), false);
+    // Canvas should still be there
+    assert.equal(fs.existsSync(path.join(root, "extensions/canvas")), true);
+
+    // Registry should be updated at root level (not .github/)
+    const updated = readUserRegistry(root);
+    assert.equal("cron" in (updated.extensions || {}), false);
+    assert.equal("canvas" in (updated.extensions || {}), true);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── pin (user-level layout) ─────────────────────────────────────────────────
+
+describe("pin (user layout)", () => {
+  it("sets local:true on item in user-level registry", () => {
+    const registry = {
+      version: "0.1.0",
+      source: "owner/repo",
+      extensions: {
+        cron: { version: "0.1.4", path: "extensions/cron", description: "Cron" },
+      },
+      skills: {},
+    };
+    const root = makeTempUserDir(registry, ["extensions/cron"]);
+
+    const result = pin(["cron"], root);
+
+    assert.equal(result.pinned.length, 1);
+    assert.equal(result.pinned[0].name, "cron");
+
+    const updated = readUserRegistry(root);
+    assert.equal(updated.extensions.cron.local, true);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("pinned user-level item shows as localOnly in diff", () => {
+    const registry = {
+      version: "0.1.0",
+      source: "owner/repo",
+      extensions: {
+        cron: { version: "0.1.4", path: "extensions/cron", description: "Cron" },
+      },
+      skills: {},
+    };
+    const root = makeTempUserDir(registry, ["extensions/cron"]);
+
+    pin(["cron"], root);
+
+    const local = readUserRegistry(root);
+    const remote = { version: "0.2.0", extensions: {}, skills: {} };
+    const diff = diffRegistries(local, remote);
+
+    assert.equal(diff.removed.length, 0);
+    assert.equal(diff.localOnly.length, 1);
+    assert.equal(diff.localOnly[0].name, "cron");
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── diffRegistries — promotion (package → template) ──────────────────────────
+
+describe("diffRegistries — promotion", () => {
+  it("detects promotion when local item has package field and remote has same name", () => {
+    const local = makeLocal({
+      extensions: {
+        weather: {
+          version: "0.1.0",
+          path: ".github/extensions/weather",
+          description: "Weather data",
+          package: "acme/tools",
+        },
+      },
+    });
+    const remote = makeRemote({
+      extensions: {
+        weather: {
+          version: "0.2.0",
+          path: ".github/extensions/weather",
+          description: "Weather data",
+        },
+      },
+    });
+
+    const diff = diffRegistries(local, remote);
+
+    assert.equal(diff.promoted.length, 1);
+    assert.equal(diff.promoted[0].name, "weather");
+    assert.equal(diff.promoted[0].package, "acme/tools");
+    assert.equal(diff.promoted[0].version, "0.2.0");
+    assert.equal(diff.promoted[0].localVersion, "0.1.0");
+    assert.equal(diff.new.length, 0);
+    assert.equal(diff.updated.length, 0);
+  });
+
+  it("does not flag non-package items as promoted", () => {
+    const local = makeLocal({
+      extensions: {
+        cron: {
+          version: "0.1.0",
+          path: ".github/extensions/cron",
+          description: "Cron",
+        },
+      },
+    });
+    const remote = makeRemote({
+      extensions: {
+        cron: {
+          version: "0.2.0",
+          path: ".github/extensions/cron",
+          description: "Cron",
+        },
+      },
+    });
+
+    const diff = diffRegistries(local, remote);
+
+    assert.equal(diff.promoted.length, 0);
+    assert.equal(diff.updated.length, 1);
+  });
+
+  it("treats package-installed items not in template as localOnly (not removed)", () => {
+    const local = makeLocal({
+      extensions: {
+        weather: {
+          version: "0.1.0",
+          path: ".github/extensions/weather",
+          description: "Weather",
+          package: "acme/tools",
+        },
+      },
+    });
+    const remote = makeRemote({ extensions: {} });
+
+    const diff = diffRegistries(local, remote);
+
+    assert.equal(diff.removed.length, 0);
+    assert.equal(diff.localOnly.length, 1);
+    assert.equal(diff.localOnly[0].name, "weather");
+  });
+});
+
+// ── promotion — registry cleanup ─────────────────────────────────────────────
+
+describe("promotion — registry cleanup", () => {
+  it("removes package field and cleans packages array on promotion", () => {
+    const registry = {
+      version: "0.14.0",
+      source: "owner/repo",
+      extensions: {
+        weather: {
+          version: "0.1.0",
+          path: ".github/extensions/weather",
+          description: "Weather",
+          package: "acme/tools",
+        },
+        cron: {
+          version: "0.1.0",
+          path: ".github/extensions/cron",
+          description: "Cron",
+        },
+      },
+      skills: {},
+      packages: [
+        {
+          source: "acme/tools",
+          ref: "main",
+          installed: {
+            extensions: {
+              weather: {
+                version: "0.1.0",
+                path: ".github/extensions/weather",
+                description: "Weather",
+              },
+            },
+            skills: {},
+          },
+        },
+      ],
+    };
+
+    const root = makeTempRepo(registry, [".github/extensions/weather", ".github/extensions/cron"]);
+    const local = readRegistry(root);
+    const name = "weather";
+    const type = "extensions";
+    const pkgSource = local[type][name].package;
+
+    // Simulate promotion: update entry without package field
+    local[type][name] = {
+      version: "0.2.0",
+      path: ".github/extensions/weather",
+      description: "Weather",
+    };
+
+    // Clean packages array (same logic as install)
+    for (const pkg of local.packages) {
+      if (pkg.source === pkgSource && pkg.installed) {
+        const pkgType = pkg.installed[type];
+        if (pkgType && pkgType[name]) {
+          delete pkgType[name];
+        }
+      }
+    }
+    local.packages = local.packages.filter((pkg) => {
+      if (!pkg.installed) return false;
+      const exts = Object.keys(pkg.installed.extensions || {});
+      const skills = Object.keys(pkg.installed.skills || {});
+      return exts.length > 0 || skills.length > 0;
+    });
+
+    assert.equal(local.extensions.weather.package, undefined);
+    assert.equal(local.extensions.weather.version, "0.2.0");
+    assert.equal(local.packages.length, 0);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("keeps package entry when other items remain after promotion", () => {
+    const registry = {
+      version: "0.14.0",
+      source: "owner/repo",
+      extensions: {
+        weather: {
+          version: "0.1.0",
+          path: ".github/extensions/weather",
+          description: "Weather",
+          package: "acme/tools",
+        },
+        forecast: {
+          version: "0.1.0",
+          path: ".github/extensions/forecast",
+          description: "Forecast",
+          package: "acme/tools",
+        },
+      },
+      skills: {},
+      packages: [
+        {
+          source: "acme/tools",
+          ref: "main",
+          installed: {
+            extensions: {
+              weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather" },
+              forecast: { version: "0.1.0", path: ".github/extensions/forecast", description: "Forecast" },
+            },
+            skills: {},
+          },
+        },
+      ],
+    };
+
+    const root = makeTempRepo(registry, [".github/extensions/weather", ".github/extensions/forecast"]);
+    const local = readRegistry(root);
+
+    const pkgSource = local.extensions.weather.package;
+    local.extensions.weather = { version: "0.2.0", path: ".github/extensions/weather", description: "Weather" };
+
+    for (const pkg of local.packages) {
+      if (pkg.source === pkgSource && pkg.installed) {
+        delete pkg.installed.extensions.weather;
+      }
+    }
+    local.packages = local.packages.filter((pkg) => {
+      if (!pkg.installed) return false;
+      const exts = Object.keys(pkg.installed.extensions || {});
+      const skills = Object.keys(pkg.installed.skills || {});
+      return exts.length > 0 || skills.length > 0;
+    });
+
+    assert.equal(local.packages.length, 1);
+    assert.equal(local.packages[0].installed.extensions.forecast.version, "0.1.0");
+    assert.equal(local.packages[0].installed.extensions.weather, undefined);
+
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+// ── migrateRegistry ──────────────────────────────────────────────────────────
+
+describe("migrateRegistry", () => {
+  it("assigns non-template items to package source", () => {
+    const local = {
+      version: "0.15.0",
+      source: "ianphil/genesis",
+      channel: "frontier",
+      extensions: {
+        cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
+        heartbeat: { version: "0.1.2", path: ".github/extensions/heartbeat", description: "Heartbeat" },
+        microui: { version: "0.1.0", path: ".github/extensions/microui", description: "MicroUI" },
+      },
+      skills: {
+        commit: { version: "0.1.0", path: ".github/skills/commit", description: "Commit" },
+        "agent-comms": { version: "0.1.0", path: ".github/skills/agent-comms", description: "Agent comms" },
+      },
+      packages: [],
+    };
+    const remote = {
+      version: "0.15.0",
+      source: "ianphil/genesis",
+      extensions: {
+        cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
+      },
+      skills: {
+        commit: { version: "0.1.0", path: ".github/skills/commit", description: "Commit" },
+      },
+    };
+
+    const { migrated, skipped } = migrateRegistry(local, remote, "ianphil/genesis-frontier");
+
+    assert.equal(migrated.length, 3);
+    const names = migrated.map((m) => m.name).sort();
+    assert.deepEqual(names, ["agent-comms", "heartbeat", "microui"]);
+
+    assert.equal(skipped.length, 2);
+    assert.ok(skipped.every((s) => s.reason === "in_template"));
+
+    // Verify package field was added
+    assert.equal(local.extensions.heartbeat.package, "ianphil/genesis-frontier");
+    assert.equal(local.extensions.microui.package, "ianphil/genesis-frontier");
+    assert.equal(local.skills["agent-comms"].package, "ianphil/genesis-frontier");
+
+    // Template items should NOT have package field
+    assert.equal(local.extensions.cron.package, undefined);
+    assert.equal(local.skills.commit.package, undefined);
+
+    // Verify packages[] array was populated
+    assert.equal(local.packages.length, 1);
+    assert.equal(local.packages[0].source, "ianphil/genesis-frontier");
+    assert.equal(local.packages[0].installed.extensions.heartbeat.version, "0.1.2");
+    assert.equal(local.packages[0].installed.extensions.microui.version, "0.1.0");
+    assert.equal(local.packages[0].installed.skills["agent-comms"].version, "0.1.0");
+    assert.equal(local.packages[0].installed.extensions.cron, undefined);
+  });
+
+  it("skips pinned items", () => {
+    const local = {
+      version: "0.15.0",
+      source: "ianphil/genesis",
+      extensions: {
+        custom: { version: "0.1.0", path: ".github/extensions/custom", description: "Custom", local: true },
+      },
+      skills: {},
+      packages: [],
+    };
+    const remote = { version: "0.15.0", source: "ianphil/genesis", extensions: {}, skills: {} };
+
+    const { migrated, skipped } = migrateRegistry(local, remote, "acme/pkg");
+
+    assert.equal(migrated.length, 0);
+    assert.equal(skipped.length, 1);
+    assert.equal(skipped[0].reason, "pinned");
+    assert.equal(local.extensions.custom.package, undefined);
+    assert.equal(local.extensions.custom.local, true);
+  });
+
+  it("skips items already owned by a package", () => {
+    const local = {
+      version: "0.15.0",
+      source: "ianphil/genesis",
+      extensions: {
+        weather: { version: "0.1.0", path: ".github/extensions/weather", description: "Weather", package: "acme/tools" },
+      },
+      skills: {},
+      packages: [{ source: "acme/tools", ref: "main", installed: { extensions: { weather: { version: "0.1.0" } }, skills: {} } }],
+    };
+    const remote = { version: "0.15.0", source: "ianphil/genesis", extensions: {}, skills: {} };
+
+    const { migrated, skipped } = migrateRegistry(local, remote, "ianphil/genesis-frontier");
+
+    assert.equal(migrated.length, 0);
+    assert.equal(skipped.length, 1);
+    assert.equal(skipped[0].reason, "already_package");
+    assert.equal(local.extensions.weather.package, "acme/tools");
+  });
+
+  it("returns empty when all items are in template", () => {
+    const local = {
+      version: "0.15.0",
+      source: "ianphil/genesis",
+      extensions: {
+        cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
+      },
+      skills: {},
+      packages: [],
+    };
+    const remote = {
+      version: "0.15.0",
+      source: "ianphil/genesis",
+      extensions: {
+        cron: { version: "0.1.4", path: ".github/extensions/cron", description: "Cron" },
+      },
+      skills: {},
+    };
+
+    const { migrated, skipped } = migrateRegistry(local, remote, "acme/pkg");
+
+    assert.equal(migrated.length, 0);
+    assert.equal(skipped.length, 1);
+    assert.equal(skipped[0].reason, "in_template");
+    assert.equal(local.packages.length, 0);
+  });
+
+  it("appends to existing packages[] entry for same source", () => {
+    const local = {
+      version: "0.15.0",
+      source: "ianphil/genesis",
+      extensions: {
+        heartbeat: { version: "0.1.2", path: ".github/extensions/heartbeat", description: "Heartbeat" },
+      },
+      skills: {
+        "new-mind": { version: "0.1.0", path: ".github/skills/new-mind", description: "Bootstrap" },
+      },
+      packages: [
+        {
+          source: "ianphil/genesis-frontier",
+          ref: "main",
+          installed: {
+            extensions: { tunnel: { version: "0.1.0", path: ".github/extensions/tunnel", description: "Tunnel" } },
+            skills: {},
+          },
+        },
+      ],
+    };
+    const remote = { version: "0.15.0", source: "ianphil/genesis", extensions: {}, skills: {} };
+
+    const { migrated } = migrateRegistry(local, remote, "ianphil/genesis-frontier");
+
+    assert.equal(migrated.length, 2);
+    assert.equal(local.packages.length, 1);
+    assert.equal(local.packages[0].installed.extensions.tunnel.version, "0.1.0");
+    assert.equal(local.packages[0].installed.extensions.heartbeat.version, "0.1.2");
+    assert.equal(local.packages[0].installed.skills["new-mind"].version, "0.1.0");
+  });
+});

--- a/.github/skills/yellow-pages/.gitignore
+++ b/.github/skills/yellow-pages/.gitignore
@@ -1,0 +1,2 @@
+jobs.json
+.cache/

--- a/.github/skills/yellow-pages/SKILL.md
+++ b/.github/skills/yellow-pages/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: yellow-pages
+description: >
+  Send messages to other agents — local or remote. The agent directory and
+  communication layer. Use when the user asks to "talk to", "contact", "message",
+  "reach", "send a message to", "ping", or "call" another agent by name. Also
+  triggers on "list agents", "who can I talk to", or "add a contact".
+---
+
+# Yellow Pages — Agent Directory & Communications
+
+Your directory of reachable agents and the tool for talking to them. One script
+handles local agents (same machine, HTTP) and remote agents (Dev Tunnels, JWT auth).
+
+## Quick Reference
+
+Run `node .github/skills/yellow-pages/send.js --help` for the full instruction
+manual — it covers every command, option, and transport detail.
+
+## Core Operations
+
+**Send a message:**
+```
+node .github/skills/yellow-pages/send.js --to <name> --message "your message"
+```
+
+**Check for replies:**
+```
+node .github/skills/yellow-pages/send.js --check
+```
+
+**List contacts:**
+```
+node .github/skills/yellow-pages/send.js --list
+```
+
+## When Someone Asks to Contact an Unknown Agent
+
+If the user asks to contact an agent not in the directory, **ask them**:
+1. What's the agent's name?
+2. Is it local (on this machine) or remote (on another machine)?
+3. If local: what port?
+4. If remote: what's the tunnel ID?
+
+Then register with `--add`:
+```
+node .github/skills/yellow-pages/send.js --add <name> --local <port>
+node .github/skills/yellow-pages/send.js --add <name> --tunnel <tunnelId>
+```
+
+## Delivery Modes
+
+- **Default (no flag):** Background job on the remote agent. Returns a job ID.
+  Trackable via `--check`. Use for tasks, requests, anything you want to follow up on.
+- **`--sync` flag:** Fire-and-forget into their current interactive session.
+  No tracking. Use for quick pings, FYIs, and messages that don't need a response.
+
+## Inbound Messages
+
+When you receive a message via the Responses API with a `From:` field in the
+envelope, the sender is identified. Look them up in contacts.json for personality
+notes and context on who they are and how to respond.
+
+## Identity
+
+Every outbound message includes an `X-Agent-Name` header identifying you as the
+sender. The receiving agent sees this in their Responses API envelope.
+
+## Hard Rules
+
+1. **Async is the default.** Use `--sync` only for quick pings or when the user asks.
+2. **Never poll or loop after sending.** Send → report job ID → move on.
+3. **Never pass `previous_response_id` across agent boundaries** — each message is self-contained.
+4. **Read stdout** for results. **Read stderr** for errors.
+5. **contacts.json is the directory.** jobs.json is ephemeral tracking (gitignored).

--- a/.github/skills/yellow-pages/contacts.json
+++ b/.github/skills/yellow-pages/contacts.json
@@ -1,0 +1,4 @@
+{
+  "self": "my-agent",
+  "contacts": []
+}

--- a/.github/skills/yellow-pages/send.js
+++ b/.github/skills/yellow-pages/send.js
@@ -1,0 +1,645 @@
+#!/usr/bin/env node
+// Yellow Pages — send.js
+// Unified inter-agent messaging: local (HTTP) and remote (Dev Tunnel + JWT).
+// contacts.json is the registry. jobs.json tracks async responses.
+// Auth cache for remote agents stored in .cache/auth-state.json.
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const os = require("os");
+
+const DIR = __dirname;
+const CONTACTS_PATH = path.join(DIR, "contacts.json");
+const JOBS_PATH = path.join(DIR, "jobs.json");
+const CACHE_DIR = path.join(DIR, ".cache");
+const AUTH_STATE_PATH = path.join(CACHE_DIR, "auth-state.json");
+
+const TOKEN_MAX_AGE_MS = 20 * 60 * 60 * 1000; // 20 hours
+const JOB_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const REQUEST_TIMEOUT_MS = 120_000;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fatal(code, message) {
+  process.stderr.write(`${code}: ${message}\n`);
+  process.exit(1);
+}
+
+function info(msg) {
+  process.stderr.write(`${msg}\n`);
+}
+
+async function fetchWithTimeout(url, options) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } catch (err) {
+    if (err.name === "AbortError") {
+      fatal("TIMEOUT", `Request to ${url} timed out after ${REQUEST_TIMEOUT_MS / 1000}s`);
+    }
+    fatal("NETWORK_ERROR", `Request to ${url} failed: ${err.message}`);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// Atomic write: temp file + rename
+function atomicWrite(filePath, data) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.tmp-${crypto.randomBytes(4).toString("hex")}`);
+  fs.writeFileSync(tmp, data, "utf-8");
+  fs.renameSync(tmp, filePath);
+}
+
+// ---------------------------------------------------------------------------
+// Contacts registry
+// ---------------------------------------------------------------------------
+
+function readContacts() {
+  if (!fs.existsSync(CONTACTS_PATH)) {
+    return { self: "moneypenny", contacts: [] };
+  }
+  try {
+    return JSON.parse(fs.readFileSync(CONTACTS_PATH, "utf-8"));
+  } catch {
+    fatal("BAD_CONTACTS", "contacts.json is malformed.");
+  }
+}
+
+function writeContacts(data) {
+  atomicWrite(CONTACTS_PATH, JSON.stringify(data, null, 2) + "\n");
+}
+
+function findContact(name) {
+  const reg = readContacts();
+  return reg.contacts.find((c) => c.name === name) || null;
+}
+
+function getSelfName() {
+  return readContacts().self || "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// Auth-state cache (remote agents)
+// ---------------------------------------------------------------------------
+
+function readAuthState() {
+  if (!fs.existsSync(AUTH_STATE_PATH)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(AUTH_STATE_PATH, "utf-8"));
+  } catch {
+    return {};
+  }
+}
+
+function writeAuthState(state) {
+  atomicWrite(AUTH_STATE_PATH, JSON.stringify(state, null, 2) + "\n");
+}
+
+function getCachedAuth(tunnelId) {
+  const state = readAuthState();
+  return state[tunnelId] || null;
+}
+
+function setCachedAuth(tunnelId, tunnelUrl, token) {
+  const state = readAuthState();
+  state[tunnelId] = {
+    tunnelUrl,
+    token,
+    mintedAt: new Date().toISOString(),
+  };
+  writeAuthState(state);
+}
+
+function isTokenFresh(cached) {
+  if (!cached || !cached.token || !cached.mintedAt) return false;
+  const minted = new Date(cached.mintedAt).getTime();
+  if (isNaN(minted)) return false;
+  return Date.now() - minted < TOKEN_MAX_AGE_MS;
+}
+
+// ---------------------------------------------------------------------------
+// Jobs tracking
+// ---------------------------------------------------------------------------
+
+function readJobs() {
+  if (!fs.existsSync(JOBS_PATH)) return [];
+  try {
+    return JSON.parse(fs.readFileSync(JOBS_PATH, "utf-8"));
+  } catch {
+    return [];
+  }
+}
+
+function writeJobs(jobs) {
+  // Auto-prune entries older than 7 days
+  const cutoff = Date.now() - JOB_MAX_AGE_MS;
+  const fresh = jobs.filter((j) => new Date(j.sent_at).getTime() > cutoff);
+  atomicWrite(JOBS_PATH, JSON.stringify(fresh, null, 2) + "\n");
+}
+
+function appendJob(id, contact, feedUrl, prompt) {
+  const jobs = readJobs();
+  jobs.push({
+    id,
+    contact,
+    feed_url: feedUrl || null,
+    prompt: prompt.length > 200 ? prompt.slice(0, 200) + "..." : prompt,
+    sent_at: new Date().toISOString(),
+  });
+  writeJobs(jobs);
+}
+
+// ---------------------------------------------------------------------------
+// Tunnel resolution & token minting
+// ---------------------------------------------------------------------------
+
+function resolveTunnelUrl(tunnelId) {
+  try {
+    const output = execSync(`devtunnel show ${tunnelId}`, {
+      encoding: "utf-8",
+      timeout: 15_000,
+    });
+    const match = output.match(/Connect via browser:\s*(https:\/\/[^\s]+)/);
+    if (match) return match[1].replace(/\/$/, "");
+    const urlMatch = output.match(/(https:\/\/[^\s]+devtunnels\.ms[^\s]*)/);
+    if (urlMatch) return urlMatch[1].replace(/\/$/, "");
+    fatal("URL_RESOLVE_FAILED", `Could not find tunnel URL in devtunnel show output:\n${output}`);
+  } catch (err) {
+    if (err.status !== undefined) {
+      fatal("URL_RESOLVE_FAILED", `devtunnel show failed: ${err.message}`);
+    }
+    throw err;
+  }
+}
+
+function mintToken(tunnelId) {
+  try {
+    info(`Minting fresh connect token for ${tunnelId}...`);
+    const output = execSync(`devtunnel token ${tunnelId} --scope connect`, {
+      encoding: "utf-8",
+      timeout: 30_000,
+    });
+    const match = output.match(/^Token:\s*(.+)$/m);
+    if (!match) {
+      fatal("TOKEN_MINT_FAILED", `Could not parse token from devtunnel output:\n${output}`);
+    }
+    return match[1].trim();
+  } catch (err) {
+    fatal("TOKEN_MINT_FAILED", `devtunnel token failed: ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transport — ensure auth for a contact
+// ---------------------------------------------------------------------------
+
+function ensureRemoteAuth(contact, forceRefresh = false) {
+  const { tunnelId } = contact;
+  if (!tunnelId) fatal("BAD_CONTACT", `Remote contact "${contact.name}" has no tunnelId.`);
+
+  let cached = getCachedAuth(tunnelId);
+
+  // Resolve tunnel URL if not cached
+  let tunnelUrl = cached?.tunnelUrl;
+  if (!tunnelUrl) {
+    tunnelUrl = resolveTunnelUrl(tunnelId);
+  }
+
+  // Mint token if needed
+  let token = cached?.token;
+  if (forceRefresh || !isTokenFresh(cached)) {
+    token = mintToken(tunnelId);
+  }
+
+  setCachedAuth(tunnelId, tunnelUrl, token);
+  return { tunnelUrl, token };
+}
+
+function buildBaseUrl(contact) {
+  if (contact.type === "local") {
+    const host = contact.host || "127.0.0.1";
+    return `http://${host}:${contact.port}`;
+  }
+  // remote — resolved during auth
+  return null;
+}
+
+function buildHeaders(contact, auth) {
+  const selfName = getSelfName();
+  const headers = {
+    "X-Agent-Name": selfName,
+  };
+  if (contact.type === "remote" && auth?.token) {
+    headers["X-Tunnel-Authorization"] = `tunnel ${auth.token}`;
+  }
+  return headers;
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+async function healthCheck(baseUrl, headers) {
+  const url = `${baseUrl}/health`;
+  let resp;
+  try {
+    resp = await fetchWithTimeout(url, { method: "GET", headers });
+  } catch {
+    // fatal already called by fetchWithTimeout
+    return;
+  }
+  if (!resp.ok) {
+    fatal("AGENT_UNREACHABLE", `Health check returned ${resp.status}: ${await resp.text()}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Send message
+// ---------------------------------------------------------------------------
+
+async function sendMessage(baseUrl, headers, message, isAsync) {
+  const url = `${baseUrl}/v1/responses`;
+  const body = JSON.stringify({
+    model: "copilot",
+    input: message,
+    stream: false,
+    async: isAsync,
+  });
+
+  const resp = await fetchWithTimeout(url, {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body,
+  });
+
+  if (resp.status === 401 || resp.status === 403) {
+    return { authFailed: true };
+  }
+
+  // Both async:true and async:false return 202
+  if (!resp.ok && resp.status !== 202) {
+    const text = await resp.text();
+    fatal("API_ERROR", `Responses API returned ${resp.status}: ${text}`);
+  }
+
+  const data = await resp.json();
+  return { authFailed: false, data };
+}
+
+// ---------------------------------------------------------------------------
+// Check job status
+// ---------------------------------------------------------------------------
+
+async function checkJob(baseUrl, headers, jobId) {
+  const url = `${baseUrl}/jobs/${encodeURIComponent(jobId)}`;
+  const resp = await fetchWithTimeout(url, { method: "GET", headers });
+  if (!resp.ok) {
+    return { id: jobId, status: "unknown", error: `HTTP ${resp.status}` };
+  }
+  return await resp.json();
+}
+
+// ---------------------------------------------------------------------------
+// CLI: --list
+// ---------------------------------------------------------------------------
+
+async function cmdList() {
+  const reg = readContacts();
+  if (reg.contacts.length === 0) {
+    process.stdout.write("No contacts registered.\n");
+    return;
+  }
+  const jobs = readJobs();
+  for (const c of reg.contacts) {
+    const pending = jobs.filter((j) => j.contact === c.name).length;
+    const tag = c.type === "local"
+      ? `local ${c.host || "127.0.0.1"}:${c.port}`
+      : `remote tunnel:${c.tunnelId}`;
+    const pendingTag = pending > 0 ? ` [${pending} pending]` : "";
+    const notesTag = c.notes ? ` — ${c.notes}` : "";
+    process.stdout.write(`  ${c.name}  (${tag})${pendingTag}${notesTag}\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CLI: --add
+// ---------------------------------------------------------------------------
+
+function cmdAdd(name, opts) {
+  const reg = readContacts();
+  if (reg.contacts.find((c) => c.name === name)) {
+    fatal("DUPLICATE", `Contact "${name}" already exists. Remove it first.`);
+  }
+
+  if (opts.local !== undefined) {
+    const port = parseInt(opts.local, 10);
+    if (!port || port < 1 || port > 65535) {
+      fatal("BAD_PORT", `Invalid port: ${opts.local}`);
+    }
+    const entry = { name, type: "local", host: opts.host || "127.0.0.1", port };
+    reg.contacts.push(entry);
+    writeContacts(reg);
+    process.stdout.write(`Added local contact: ${name} at ${entry.host}:${port}\n`);
+    return;
+  }
+
+  if (opts.tunnel) {
+    // Validate devtunnel CLI exists
+    try {
+      execSync("devtunnel --version", { encoding: "utf-8", timeout: 10_000, stdio: "pipe" });
+    } catch {
+      fatal("NO_DEVTUNNEL", "devtunnel CLI not found on PATH. Install it first.");
+    }
+    // Validate tunnel ID resolves
+    info(`Validating tunnel ${opts.tunnel}...`);
+    const tunnelUrl = resolveTunnelUrl(opts.tunnel);
+    info(`Resolved: ${tunnelUrl}`);
+
+    // Cache the resolved URL
+    setCachedAuth(opts.tunnel, tunnelUrl, null);
+
+    const entry = { name, type: "remote", tunnelId: opts.tunnel };
+    reg.contacts.push(entry);
+    writeContacts(reg);
+    process.stdout.write(`Added remote contact: ${name} via tunnel ${opts.tunnel}\n`);
+    return;
+  }
+
+  fatal("USAGE", "Specify --local <port> or --tunnel <tunnelId>");
+}
+
+// ---------------------------------------------------------------------------
+// CLI: --remove
+// ---------------------------------------------------------------------------
+
+function cmdRemove(name) {
+  const reg = readContacts();
+  const idx = reg.contacts.findIndex((c) => c.name === name);
+  if (idx === -1) {
+    fatal("NOT_FOUND", `Contact "${name}" not found.`);
+  }
+  reg.contacts.splice(idx, 1);
+  writeContacts(reg);
+  process.stdout.write(`Removed contact: ${name}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// CLI: --check
+// ---------------------------------------------------------------------------
+
+async function cmdCheck(contactName) {
+  const jobs = readJobs();
+  const toCheck = contactName
+    ? jobs.filter((j) => j.contact === contactName)
+    : jobs;
+
+  if (toCheck.length === 0) {
+    process.stdout.write(contactName
+      ? `No pending jobs for ${contactName}.\n`
+      : "No pending jobs.\n");
+    return;
+  }
+
+  // Group jobs by contact to minimize auth overhead
+  const byContact = new Map();
+  for (const job of toCheck) {
+    if (!byContact.has(job.contact)) byContact.set(job.contact, []);
+    byContact.get(job.contact).push(job);
+  }
+
+  const terminal = new Set(["completed", "failed", "cancelled"]);
+  const remaining = [...jobs];
+
+  for (const [cName, cJobs] of byContact) {
+    const contact = findContact(cName);
+    if (!contact) {
+      info(`WARN: Contact "${cName}" not found — skipping ${cJobs.length} job(s).`);
+      continue;
+    }
+
+    let baseUrl, headers;
+    if (contact.type === "local") {
+      baseUrl = buildBaseUrl(contact);
+      headers = buildHeaders(contact, null);
+    } else {
+      const auth = ensureRemoteAuth(contact);
+      baseUrl = auth.tunnelUrl;
+      headers = buildHeaders(contact, auth);
+    }
+
+    for (const job of cJobs) {
+      const result = await checkJob(baseUrl, headers, job.id);
+      const status = result.status || "unknown";
+
+      if (terminal.has(status)) {
+        const responseText = result.response
+          || (result.statusItems || [])
+              .filter((i) => i.title === "Response")
+              .pop()?.description
+          || null;
+        if (responseText) {
+          process.stdout.write(`[${status.toUpperCase()}] ${job.id} (${cName}): ${responseText}\n`);
+        } else {
+          process.stdout.write(`[${status.toUpperCase()}] ${job.id} (${cName}): (no response body)\n`);
+        }
+        const idx = remaining.findIndex((j) => j.id === job.id);
+        if (idx !== -1) remaining.splice(idx, 1);
+      } else {
+        process.stdout.write(`[${status.toUpperCase()}] ${job.id} (${cName}): still processing (sent ${job.sent_at})\n`);
+      }
+    }
+  }
+
+  writeJobs(remaining);
+}
+
+// ---------------------------------------------------------------------------
+// CLI: --send (--to + --message)
+// ---------------------------------------------------------------------------
+
+async function cmdSend(contactName, message, sync) {
+  const contact = findContact(contactName);
+  if (!contact) {
+    fatal("NOT_FOUND", `Contact "${contactName}" not found. Use --list to see contacts.`);
+  }
+
+  const isAsync = !sync;
+  let baseUrl, headers, auth;
+
+  if (contact.type === "local") {
+    baseUrl = buildBaseUrl(contact);
+    headers = buildHeaders(contact, null);
+  } else {
+    auth = ensureRemoteAuth(contact);
+    baseUrl = auth.tunnelUrl;
+    headers = buildHeaders(contact, auth);
+  }
+
+  // Health check
+  await healthCheck(baseUrl, headers);
+
+  // Send
+  let result = await sendMessage(baseUrl, headers, message, isAsync);
+
+  // Auth retry for remote agents
+  if (result.authFailed && contact.type === "remote") {
+    info("Token rejected. Refreshing and retrying...");
+    auth = ensureRemoteAuth(contact, true);
+    headers = buildHeaders(contact, auth);
+    baseUrl = auth.tunnelUrl;
+
+    result = await sendMessage(baseUrl, headers, message, isAsync);
+    if (result.authFailed) {
+      fatal("AUTH_FAILED", "Authentication failed even with a fresh token. Check tenant identity and tunnel ownership.");
+    }
+  } else if (result.authFailed) {
+    fatal("AUTH_FAILED", `Unexpected 401/403 from local agent "${contactName}".`);
+  }
+
+  // Output
+  if (isAsync) {
+    // async:true — background job with tracking
+    const jobId = result.data.id || "unknown";
+    const feedUrl = result.data.feed_url || "";
+    // Rewrite loopback feed URL for remote agents
+    const resolvedFeedUrl = contact.type === "remote" && feedUrl
+      ? feedUrl.replace(/^https?:\/\/127\.0\.0\.1:\d+/, baseUrl)
+      : feedUrl;
+    appendJob(jobId, contactName, resolvedFeedUrl, message);
+    process.stdout.write(`ACCEPTED: ${jobId}\n`);
+  } else {
+    // async:false — fire-and-forget into their current session
+    process.stdout.write("Sent.\n");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// --help
+// ---------------------------------------------------------------------------
+
+function cmdHelp() {
+  process.stdout.write(`Yellow Pages — send messages to other agents on the local network or via Dev Tunnels.
+
+SENDING MESSAGES
+  send.js --to q --message "Hello"              Background job (default) — returns job ID
+  send.js --to q --message "Hello" --sync       Fire-and-forget into their current session
+  send.js --to skippy --message "Deploy now"    Remote agent (auto-detected from contact type)
+
+  Default (no flag): sends async:true — creates a background job on the remote
+  agent. Returns a job ID you can check later with --check. Use for tasks.
+
+  --sync: sends async:false — injects the message into the agent's current
+  interactive session. No job ID, no tracking. Just prints "Sent."
+  Use for quick pings and conversational messages.
+
+  Both modes return immediately. The difference is tracking, not blocking.
+
+CHECKING REPLIES
+  send.js --check                               Check all pending background jobs
+  send.js --check --to q                        Check jobs for a specific agent
+
+  Completed jobs print their response and are removed from tracking.
+  Still-processing jobs show their sent timestamp.
+
+MANAGING CONTACTS
+  send.js --list                                Show all contacts
+  send.js --add q --local 15211                 Register local agent on port 15211
+  send.js --add q --local 15211 --host 10.0.0.5  Custom host (default: 127.0.0.1)
+  send.js --add skippy --tunnel swift-horse-9fq Register remote agent via Dev Tunnel
+  send.js --remove skippy                       Remove a contact
+
+  Local agents: direct HTTP, no auth needed.
+  Remote agents: Dev Tunnel + JWT auth, auto-managed.
+
+CONTACT TYPES
+  local    Direct HTTP to host:port. For agents on this machine or local network.
+  remote   Dev Tunnel with Entra JWT auth. For agents on other machines.
+
+NOTES
+  - Every message includes X-Agent-Name header identifying the sender.
+  - Remote tokens are cached for 20 hours and auto-refresh.
+  - Jobs older than 7 days are automatically cleaned up.
+  - contacts.json is the directory. jobs.json is ephemeral tracking.
+`);
+}
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {
+    to: null,
+    message: null,
+    sync: false,
+    list: false,
+    add: null,
+    remove: null,
+    check: false,
+    help: false,
+    local: undefined,
+    tunnel: null,
+    host: null,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const next = () => {
+      if (i + 1 >= args.length) fatal("USAGE", `Missing value for ${arg}`);
+      return args[++i];
+    };
+    switch (arg) {
+      case "--to":       parsed.to = next(); break;
+      case "--message":  parsed.message = next(); break;
+      case "--sync":     parsed.sync = true; break;
+      case "--list":     parsed.list = true; break;
+      case "--add":      parsed.add = next(); break;
+      case "--remove":   parsed.remove = next(); break;
+      case "--check":    parsed.check = true; break;
+      case "--help":
+      case "-h":         parsed.help = true; break;
+      case "--local":    parsed.local = next(); break;
+      case "--tunnel":   parsed.tunnel = next(); break;
+      case "--host":     parsed.host = next(); break;
+      default:
+        fatal("USAGE", `Unknown argument: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const opts = parseArgs();
+
+  if (opts.help || process.argv.length <= 2) {
+    cmdHelp();
+    return;
+  }
+
+  if (opts.list)   { await cmdList(); return; }
+  if (opts.add)    { cmdAdd(opts.add, opts); return; }
+  if (opts.remove) { cmdRemove(opts.remove); return; }
+  if (opts.check)  { await cmdCheck(opts.to); return; }
+
+  // Send mode
+  if (!opts.to)      fatal("USAGE", "Missing --to <name>");
+  if (!opts.message)  fatal("USAGE", "Missing --message <text>");
+  await cmdSend(opts.to, opts.message, opts.sync);
+}
+
+main().catch((err) => {
+  fatal("UNEXPECTED", err.message);
+});

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,24 @@
 node_modules/
+
+# Extensions — shared
+.github/extensions/*/node_modules/
+.github/extensions/*/package-lock.json
+.github/extensions/package-lock.json
+
+# Cron extension runtime data (local state, not version controlled)
+.github/extensions/cron/data/*/
+.github/extensions/cron/data/jobs/*.json
+.github/extensions/cron/data/history/*.json
+.github/extensions/cron/data/engine.lock
+.github/extensions/cron/data/engine.log
+
+# Canvas extension runtime data
+.github/extensions/canvas/data/content/
+!.github/extensions/canvas/data/content/test-canvas.html
+
+# Responses extension runtime data
+.github/extensions/responses/data/*/
+
 **/bin/Debug/
 **/bin/Release/
 **/obj/


### PR DESCRIPTION
Part of ianphil/chamber#67.

Retires core extensions from genesis (now built into Chamber as of v0.26.0/v0.27.0) and houses the remaining capability extensions/skills in the frontier package.

**Extensions added:** canvas@0.1.3, cron@0.4.0, idea@0.1.0, responses@0.9.0
**Skills added:** packages@0.2.0, upgrade@0.6.0, yellow-pages@0.1.0

Registry bumped 0.7.0 → 0.8.0. .gitignore updated to match genesis runtime-data exclusions.